### PR TITLE
Fix duplicate Express listener configuration

### DIFF
--- a/app.js
+++ b/app.js
@@ -213,15 +213,11 @@ app.post('/executeV2', async (req, res) => {
   }
 });
 
-const PORT = process.env.PORT || 3002;
-app.listen(PORT, () => {
-  console.log(`Server is running on port ${PORT}`);
-});
-
+const PORT = process.env.PORT || 3001;
 app.get('/health', (req, res) => {
   res.send('Server is up and running');
 });
 
-app.listen(app.get('port'), () => {
-  console.log(`Express is running at localhost: ${app.get('port')}`)
-})
+app.listen(PORT, () => {
+  console.log(`Express is running at localhost: ${PORT}`)
+});


### PR DESCRIPTION
## Summary
- remove the duplicate Express listener and reuse a single port configuration
- keep the health endpoint available while simplifying the startup log message

## Testing
- node app.js

------
https://chatgpt.com/codex/tasks/task_e_68d659c8a71c83308b2b6be479ff7b0a