### PR TITLE
Improve SMS custom activity validation and provider resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,121 @@ This repository aims to instruct beginners on how to create custom activities in
 - For additional examples/documentation on Salesforce Marketing Cloud Custom Activities check the [github](https://github.com/salesforce-marketingcloud/sfmc-example-jb-custom-activity) and [documentation](https://developer.salesforce.com/docs/marketing/marketing-cloud/guide/creating-activities.html)
 ## Postman Collection
 A Postman collection covering every HTTP endpoint exposed by `app.js` is available at `postman/sfmc-custom-activity.postman_collection.json`. Import it into Postman and update the `baseUrl` variable to match your deployment host before sending requests.
+
+## SMS Activity Hardening Notes
+
+### Setup
+
+1. Install dependencies and start the local server:
+
+   ```bash
+   npm install
+   npm start
+   ```
+
+2. Point your Marketing Cloud custom activity package to the public URL that proxies to this server (for local development use a tunnelling tool such as `ngrok`).
+
+### Required environment variables
+
+| Variable | Description |
+| --- | --- |
+| `PUBLIC_BASE_URL` | Overrides the auto-detected host when generating `config.json` links. Recommended for production deployments behind load balancers. |
+| `DIGO_API_URL` | (Optional) SMS provider endpoint. Defaults to `https://engage-api.digo.link/notify`. |
+| `DIGO_X_AUTHORIZATION` | Value for the `X-Authorization` header required by the SMS provider. |
+| `DIGO_BEARER_TOKEN` | Bearer token passed in the `Authorization` header. |
+| `DIGO_HTTP_TIMEOUT_MS` | (Optional) Timeout in milliseconds for the outbound SMS request. Defaults to `15000`. |
+| `DIGO_RETRY_ATTEMPTS` | (Optional) How many times to retry provider calls on retryable failures. Defaults to `3`. |
+| `DIGO_RETRY_BACKOFF_MS` | (Optional) Base delay in milliseconds used for exponential backoff. Defaults to `500`. |
+| `DIGO_DEFAULT_MSISDNS` | Comma-separated list of fallback MSISDNs used when `dataSet` is not provided by Journey Builder. |
+| `DIGO_ORIGINATOR` | (Optional) Originator string for the SMS payload. Defaults to `TACMPN`. |
+| `DIGO_STUB_MODE` | When set to `true`, skips the outbound call and echoes the payload for integration testing. |
+
+### Validating the execute payload
+
+The Journey Builder canvas must submit an `execute` payload containing the following structure in `inArguments[0]`:
+
+```json
+{
+  "transactionID": "txn-123",           // optional, generated automatically if omitted
+  "campaignName": "September SMS Push",
+  "tiny": "1",                          // string, must be "0" or "1"
+  "PE_ID": "PE123456",
+  "TEMPLATE_ID": "TMP-001",
+  "TELEMARKETER_ID": "TMK-2024",
+  "message": "Hello from Journey Builder!",
+  "dataSet": [                           // optional override for target MSISDNs
+    { "msisdn": "911234567890", "message": "Hello from Journey Builder!" }
+  ]
+}
+```
+
+### Sample execute request
+
+```http
+POST /executeV2 HTTP/1.1
+Host: your-domain.example.com
+Content-Type: application/json
+X-Correlation-Id: 4ff5a4e0-8433-4dc3-9c8b-a310816a0132
+
+{
+  "keyValue": "{{Context.ContactKey}}",
+  "inArguments": [
+    {
+      "transactionID": "txn-20230926-001",
+      "campaignName": "Journey Kickoff",
+      "tiny": "1",
+      "PE_ID": "PE12345",
+      "TEMPLATE_ID": "TEMPLATE-001",
+      "TELEMARKETER_ID": "TMK001",
+      "message": "Thank you for joining our program!"
+    }
+  ]
+}
+```
+
+Successful response example:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+X-Correlation-Id: 4ff5a4e0-8433-4dc3-9c8b-a310816a0132
+
+{
+  "status": "ok",
+  "transactionID": "txn-20230926-001",
+  "providerStatus": 202,
+  "providerResponse": {
+    "message": "Accepted",
+    "ticketId": "abc123"
+  }
+}
+```
+
+To reproduce the validation behaviour locally you can send the sample payload via `curl`:
+
+```bash
+curl -X POST "http://localhost:3001/executeV2" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "keyValue": "contact-key",
+    "inArguments": [
+      {
+        "transactionID": "txn-local-001",
+        "campaignName": "Local Test",
+        "tiny": "1",
+        "PE_ID": "PE123",
+        "TEMPLATE_ID": "TMP-123",
+        "TELEMARKETER_ID": "TMK-123",
+        "message": "Integration test"
+      }
+    ]
+  }'
+```
+
+When `DIGO_STUB_MODE=true` the response body includes the echoed payload so you can validate downstream integrations without reaching the SMS provider.
+
+### Known edge cases
+
+- Requests without MSISDNs in `dataSet` and without `DIGO_DEFAULT_MSISDNS` configured will be rejected with a validation error because the downstream provider requires at least one recipient.
+- Provider errors that return HTTP status codes below `500` (for example `400` or `401`) are treated as permanent failures; retries stop immediately and Journey Builder receives the provider status.
+- Journey Builder may call `/save`, `/publish`, `/validate`, or `/stop` with empty bodies when the canvas is initialising. These requests are allowed and logged, but validation occurs automatically once `inArguments` are present.

--- a/app.js
+++ b/app.js
@@ -11,47 +11,50 @@
 const express = require('express');
 const bodyParser = require('body-parser');
 const path = require('path');
-const axios = require('axios')
-var http = require('https');
-var request = require('request');
-const app = express();
 const configJSON = require('./config-json');
 const uuid = require('uuid');
+const logger = require('./lib/logger');
+const { ValidationError, validateExecuteRequest } = require('./lib/activity-validation');
+const { buildDigoPayload } = require('./lib/digo-payload');
+const { sendPayloadWithRetry, ProviderRequestError } = require('./lib/digo-client');
+
+const app = express();
 
 const designSystemAssetsPath = path.join(
   __dirname,
   'node_modules/@salesforce-ux/design-system/assets'
 );
 
-let logger = (label, item) => {
-  const debug = true
-  if (debug) {
-    console.log(label)
-    console.log(item)
-  }
-}
-
 // Configure Express
 app.set('port', process.env.PORT || 3001);
-app.use(bodyParser.json());
-app.use(express.static(path.join(__dirname, 'dist')))
+app.use(bodyParser.json({ limit: '1mb' }));
+app.use(express.static(path.join(__dirname, 'dist')));
 app.use('/assets', express.static(designSystemAssetsPath));
+app.use('/images', express.static(path.join(__dirname, 'images')));
+
+// Attach a correlation id for every request so that logs are traceable.
+app.use((req, res, next) => {
+  const correlationId = req.headers['x-correlation-id'] || uuid.v4();
+  req.correlationId = correlationId;
+  res.set('X-Correlation-Id', correlationId);
+  next();
+});
 
 app.get('/', (req, res) => {
-  return res.sendFile(path.join(__dirname, 'index.html'))
-})
+  return res.sendFile(path.join(__dirname, 'index.html'));
+});
 
 app.get('/index.html', (req, res) => {
-  return res.sendFile(path.join(__dirname, 'index.html'))
-})
+  return res.sendFile(path.join(__dirname, 'index.html'));
+});
 
 app.get('/main.js', (req, res) => {
-  return res.sendFile(path.join(__dirname, 'main.js'))
-})
+  return res.sendFile(path.join(__dirname, 'main.js'));
+});
 
 app.get('/main.js.map', (req, res) => {
-  return res.sendFile(path.join(__dirname, 'main.js.map'))
-})
+  return res.sendFile(path.join(__dirname, 'main.js.map'));
+});
 
 // setup config.json route
 app.get('/config.json', function (req, res) {
@@ -60,170 +63,88 @@ app.get('/config.json', function (req, res) {
   return res.status(200).json(configJSON(req));
 });
 
-/**
- * Called when a journey is saving the activity.
- * @return {[type]}     [description]
- * 200 - Return a 200 iff the configuraiton is valid.
- * 30x - Return if the configuration is invalid (this will block the publish phase)
- * 40x - Return if the configuration is invalid (this will block the publish phase)
- * 50x - Return if the configuration is invalid (this will block the publish phase)
- */
-app.post('/save', function (req, res) {
-  console.log('debug: /save');
-  return res.status(200).json({});
-});
-
-/**
- * Called when a Journey has been published.
- * This is when a journey is being activiated and eligible for contacts
- * to be processed.
- * @return {[type]}     [description]
- * 200 - Return a 200 iff the configuraiton is valid.
- * 30x - Return if the configuration is invalid (this will block the publish phase)
- * 40x - Return if the configuration is invalid (this will block the publish phase)
- * 50x - Return if the configuration is invalid (this will block the publish phase)
- */
-app.post('/publish', function (req, res) {
-  console.log('debug: /publish');
-  return res.status(200).json({});
-});
-
-
-/**
- * Called when Journey Builder wants you to validate the configuration
- * to ensure the configuration is valid.
- * @return {[type]}
- * 200 - Return a 200 iff the configuraiton is valid.
- * 30x - Return if the configuration is invalid (this will block the publish phase)
- * 40x - Return if the configuration is invalid (this will block the publish phase)
- * 50x - Return if the configuration is invalid (this will block the publish phase)
- */
-app.post('/validate', function (req, res) {
-  console.log('debug: /validate');
-  return res.status(200).json({});
-});
-
-/**
- * Called when a Journey is stopped.
- * @return {[type]}
- */
-app.post('/stop', function (req, res) {
-  console.log('debug: /stop');
-  return res.status(200).json({});
-});
-
-
-{
-  inArguments: [
-    {
-      urlString: 'https://sfmc.comsensetechnologies.com/',
-      payload: [Object]
+function acknowledgeLifecycleEvent(routeName) {
+  return (req, res) => {
+    logger.info(`${routeName} lifecycle hook invoked.`, { correlationId: req.correlationId });
+    try {
+      if (req.body && Array.isArray(req.body.inArguments) && req.body.inArguments.length > 0) {
+        validateExecuteRequest(req.body);
+      }
+    } catch (error) {
+      if (error instanceof ValidationError) {
+        logger.warn(`${routeName} validation failed.`, { errors: error.details, correlationId: req.correlationId });
+        return res.status(error.statusCode).json({
+          status: 'invalid',
+          message: error.message,
+          details: error.details
+        });
+      }
+      logger.error(`${routeName} unexpected error.`, { message: error.message, correlationId: req.correlationId });
+      return res.status(500).json({ status: 'error', message: 'Unexpected error validating lifecycle request.' });
     }
-  ];
-  outArguments: [];
-  activityObjectID: '9841db2b-a598-4b3a-b1af-0dd71cd8939a';
-  journeyId: 'b544882d-4160-4114-a419-7ff43e776b47';
-  activityId: '9841db2b-a598-4b3a-b1af-0dd71cd8939a';
-  definitionInstanceId: '4f60d95d-663e-468d-896a-d85c73a46f4a';
-  activityInstanceId: '394345a0-38f5-4b1b-9223-a271e6046f7f';
-  keyValue: '00Q4S000002CsSdUAK_v2';
-  mode: 0
+
+    return res.status(200).json({ status: 'ok' });
+  };
 }
 
+app.post('/save', acknowledgeLifecycleEvent('save'));
+app.post('/publish', acknowledgeLifecycleEvent('publish'));
+app.post('/validate', acknowledgeLifecycleEvent('validate'));
+app.post('/stop', acknowledgeLifecycleEvent('stop'));
+
 app.post('/executeV2', async (req, res) => {
+  const correlationId = req.correlationId;
+  logger.info('executeV2 invoked.', { correlationId });
+
   try {
-    // Logging the request body
-    console.log('req.body', req.body);
-    const transactionID = uuid.v4();
+    const validatedArgs = validateExecuteRequest(req.body);
+    const providerPayload = buildDigoPayload(validatedArgs, {
+      dataSetOverride: validatedArgs.rawArguments.dataSet
+    });
 
-    if (Object.keys(req.body.inArguments[0]).length > 0) {
-      console.log('Preparing payload and making request to URL...');
-      const contactKey = req.body.keyValue;
-      // const transactionID = req.body.inArguments[0].transactionID;
-      const campaignName = req.body.inArguments[0].campaignName;
-      const tiny = req.body.inArguments[0].tiny;
-      const PE_ID = req.body.inArguments[0].PE_ID;
-      const TEMPLATE_ID = req.body.inArguments[0].TEMPLATE_ID;
-      const TELEMARKETER_ID = req.body.inArguments[0].TELEMARKETER_ID;
-      const message = req.body.inArguments[0].message;
+    logger.debug('Prepared provider payload.', {
+      correlationId,
+      payloadPreview: { ...providerPayload, dataSet: `[${providerPayload.dataSet.length} recipients]` }
+    });
 
+    const providerResponse = await sendPayloadWithRetry(providerPayload, {
+      headers: { 'X-Correlation-Id': correlationId }
+    });
 
-      // Constructing the payload for the cURL request
-      const payload = {
-        transactionID: transactionID,
-        campaignName: campaignName,
-        oa: "TACMPN",
-        channel: "sms",
-        tiny: tiny,
-        tlv: {
-          PE_ID: PE_ID,
-          TEMPLATE_ID: TEMPLATE_ID,
-          TELEMARKETER_ID: TELEMARKETER_ID
-        },
-        dataSet: [
-          {
-            msisdn: "917218980233",
-            message: message
-          },
-          {
-            msisdn: "918208182849",
-            message: message
-          },
-          {
-            msisdn: "918010843817",
-            message: message
-          },
-          {
-            msisdn: "919545569352",
-            message: message
-          },
-          {
-            msisdn: "919769531784",
-            message: message
-          },
-          {
-            msisdn: "918826945805",
-            message: message
-          },
-          {
-            msisdn: "919922492150",
-            message: message
-          },
-          {
-            msisdn: "917397919560",
-            message: message
-          }
-        ]
-      };
-
-      // Sending the payload to the provided URL using request module
-      request({
-        method: 'POST',
-        url: 'https://engage-api.digo.link/notify',
-        headers: {
-          'X-Authorization': 'Basic dGNsLXRhdGFtb3RybXRlbmdhcGlwcmVmZW50aW5kb210bHZwcm9tbzpkU1dOelhhZg==',
-          'Content-Type': 'application/json',
-          'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJfaWQiOiI2NTU1ZGVmMGE0OTE1YzQ2Yzg5MDk5MmIiLCJmaXJzdE5hbWUiOiJUQVRBIiwibGFzdE5hbWUiOiJNT1RPUlMgTElNSVRFRCIsImVtYWlsIjoiVGF0YV9tb3RvcnMiLCJyb2xlIjoidXNlciIsIm9yZ0lkIjoiNjU0ODg3N2NlZmYxMzEyNzhkZjZjM2MzIiwiaWF0IjoxNzAwMTI2NDg4fQ.C0eCpKOYgamfqcAO4Xu8fHm4zZdJFlWncXfX7Ddya6c'
-        },
-        json: payload
-      }, (error, response, body) => {
-        if (error) {
-          return res.status(500).json({ errorMessage: error.message });
-        }
-
-        console.log('API Response:', body); // Log the response from the API
-        return res.status(200).json({
-          message: body, // Modify the response message as needed
-
-        });
-      });
-    } else {
-      return res.status(500).json({
-        errorMessage: 'req.body.urlString did not exist'
+    return res.status(200).json({
+      status: 'ok',
+      transactionID: providerPayload.transactionID,
+      providerStatus: providerResponse.status,
+      providerResponse: providerResponse.data
+    });
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      logger.warn('executeV2 validation failed.', { errors: error.details, correlationId });
+      return res.status(error.statusCode).json({
+        status: 'invalid',
+        message: error.message,
+        details: error.details
       });
     }
-  } catch (errorMessage) {
-    return res.status(500).json({ errorMessage });
+
+    if (error instanceof ProviderRequestError) {
+      logger.error('executeV2 provider call failed.', {
+        correlationId,
+        details: error.details
+      });
+      const statusCode = error.statusCode && error.statusCode < 500 ? error.statusCode : 502;
+      return res.status(statusCode).json({
+        status: 'provider_error',
+        message: error.message,
+        details: error.details
+      });
+    }
+
+    logger.error('executeV2 unexpected error.', { correlationId, message: error.message });
+    return res.status(500).json({
+      status: 'error',
+      message: 'Unexpected error executing activity.'
+    });
   }
 });
 
@@ -233,5 +154,7 @@ app.get('/health', (req, res) => {
 });
 
 app.listen(PORT, () => {
-  console.log(`Express is running at localhost: ${PORT}`)
+  logger.info(`Express is running at localhost: ${PORT}`);
 });
+
+module.exports = app;

--- a/config-json.js
+++ b/config-json.js
@@ -1,111 +1,111 @@
 // ****************
 // *
-// * 
+// *
 // config-json.js (AKA config.JSON)
 // *
-// APPLICATION EXTENSION THAT DEFINES YOUR CUSTOM ACTIVITY 
+// APPLICATION EXTENSION THAT DEFINES YOUR CUSTOM ACTIVITY
 // *
 // *
 // ****************
 
+function resolveBaseUrl(req) {
+  if (process.env.PUBLIC_BASE_URL) {
+    return process.env.PUBLIC_BASE_URL;
+  }
+  if (!req || !req.protocol || !req.get) {
+    return '';
+  }
+  return `${req.protocol}://${req.get('host')}`;
+}
 
 module.exports = function configJSON(req) {
+  const baseUrl = resolveBaseUrl(req);
+  const iconUrl = `${baseUrl}/images/iconSmall.svg`;
+
   return {
     workflowApiVersion: '1.1',
-    // metaData points 
     metaData: {
-      icon: 'images/iconSmall.png',
+      icon: iconUrl,
+      iconSmall: iconUrl,
       category: 'message'
     },
     type: 'REST',
     lang: {
       'en-US': {
-        name: 'Custom Code Activity',
-        description: 'Makes a POST call with payload to a specific URL'
+        name: 'Custom SMS Activity',
+        description: 'Configures and triggers the DIGO SMS send API with validated payloads.'
       }
     },
-    // Contains information sent to the activity each time it executes. 
-    // See: https://developer.salesforce.com/docs/atlas.en-us.mc-apis.meta/mc-apis/how-data-binding-works.htm
     arguments: {
-      // The API calls this method for each contact processed by the journey
       execute: {
-        // Any static or data bound value configured for the activity. By default, the config.json file sets these arguments. Or you can add inArguments at configuration time
         inArguments: [],
-        // Key and Value pair for each field expected in the response body of the request
         outArguments: [],
-        // The amount of time we want JB to wait before canceling the request. Default is 60000, Minimum is 1000
         timeout: 90000,
-        // how many retries if the request failed with 5xx error or network error
         retryCount: 5,
-        // wait in ms between retry
         retryDelay: 1000,
-        // the number of concurrent requests JB will send all together
         concurrentRequests: 5,
-        // url:'https://customactivityv2.herokuapp.com/execute',
-        // url:'http://localhost:3001/executeV2',
-        url:'https://sfmc.comsensetechnologies.com/executeV2',
-      },
+        url: `${baseUrl}/executeV2`
+      }
     },
-
     configurationArguments: {
       save: {
-        url: 'https://sfmc.comsensetechnologies.com/save'
+        url: `${baseUrl}/save`
       },
       publish: {
-        url: 'https://sfmc.comsensetechnologies.com/publish'
+        url: `${baseUrl}/publish`
       },
       validate: {
-        url: 'https://sfmc.comsensetechnologies.com/validate'
+        url: `${baseUrl}/validate`
       },
       stop: {
-        url: 'https://sfmc.comsensetechnologies.com/stop'
+        url: `${baseUrl}/stop`
       }
     },
-
-    // configurationArguments: {
-    //   save: {
-    //     url: 'https://customactivityv2.herokuapp.com/save'
-    //   },
-    //   publish: {
-    //     url: 'https://customactivityv2.herokuapp.com/publish'
-    //   },
-    //   validate: {
-    //     url: 'https://customactivityv2.herokuapp.com/validate'
-    //   },
-    //   stop: {
-    //     url: 'https://customactivityv2.herokuapp.com/stop'
-    //   }
-    // },
-
-    // userInterfaces: {
-    //   configModal: {
-    //     fullscreen: false
-    //   }
-    // },
-
-    // schema Object mirrors the activity configuration from the top level of the config.json file and specifies schema information about in and out arguments. Schema objects follow this pattern: 
-    // ** 
-    // {
-    //    dataType: MC Data Type,
-    //    isNullable: boolean,
-    //    direction: "in" or "out",
-    //    access: "visible" or "hidden"
-    // }
     schema: {
       arguments: {
         execute: {
           inArguments: [
-            { 
-              urlString: {
-                dataType: 'Text',
-                isNullable: 'False',
-                direction: 'out',
-                access: 'visible'
-              },
-              payload: {
+            {
+              transactionID: {
                 dataType: 'Text',
                 isNullable: 'True',
-                direction: 'out',
+                direction: 'in',
+                access: 'visible'
+              },
+              campaignName: {
+                dataType: 'Text',
+                isNullable: 'False',
+                direction: 'in',
+                access: 'visible'
+              },
+              tiny: {
+                dataType: 'Text',
+                isNullable: 'False',
+                direction: 'in',
+                access: 'visible'
+              },
+              PE_ID: {
+                dataType: 'Text',
+                isNullable: 'False',
+                direction: 'in',
+                access: 'visible'
+              },
+              TEMPLATE_ID: {
+                dataType: 'Text',
+                isNullable: 'False',
+                direction: 'in',
+                access: 'visible'
+              },
+              TELEMARKETER_ID: {
+                dataType: 'Text',
+                isNullable: 'False',
+                direction: 'in',
+                access: 'visible'
+              },
+              message: {
+                dataType: 'Text',
+                isNullable: 'False',
+                direction: 'in',
                 access: 'visible'
               }
             }
@@ -114,5 +114,5 @@ module.exports = function configJSON(req) {
         }
       }
     }
-  }
-}
+  };
+};

--- a/images/iconSmall.svg
+++ b/images/iconSmall.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="96" height="96" viewBox="0 0 96 96" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1b96ff" />
+      <stop offset="100%" stop-color="#0f6abf" />
+    </linearGradient>
+  </defs>
+  <rect width="96" height="96" rx="18" fill="url(#grad)" />
+  <g fill="#ffffff" transform="translate(20 20)">
+    <path d="M24 0c13.255 0 24 10.745 24 24S37.255 48 24 48 0 37.255 0 24 10.745 0 24 0zm0 6C15.163 6 8 13.163 8 22c0 4.15 1.326 7.977 3.57 11.044l-1.342 9.174 8.735-4.611A15.878 15.878 0 0024 38c8.837 0 16-7.163 16-16S32.837 6 24 6z" />
+    <circle cx="24" cy="21" r="4" />
+    <path d="M24 28c-5.333 0-8 1.778-8 5.333 0 .444.089.867.242 1.273l7.098-3.749a2 2 0 011.873 0l7.097 3.75c.153-.406.243-.83.243-1.274C32 29.778 29.333 28 24 28z" />
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -133,17 +133,18 @@
 <body>
     <img class="hero-banner" src="assets/images/themes/oneSalesforce/banner-group-unlisted-default.png" />
     <div class="slds-form slds-m-around--medium activity-wrapper">
-        <h2 class="slds-page-header__title slds-truncate section-title">
-            </h1>
+        <h2 class="slds-page-header__title slds-truncate section-title"></h2>
             <div id="step1" class="step">
                 <h2 class="section-title">SMS Send API:</h2>
                 <hr>
 
-                <!-- <div>
+                <div class="form-field">
                     <div><label for="transactionID">Transaction ID:</label></div>
                     <input class="slds-form-element__control" id="transactionID" type="text" name="transactionID"
-                        value="">
-                </div> -->
+                        placeholder="Auto-generated if left blank">
+                    <span class="helper-text">Leave blank to automatically generate a unique identifier when the
+                        activity is saved.</span>
+                </div>
 
                 <div class="form-field">
                     <div><label for="campaignName">Campaign Name:</label></div>
@@ -179,6 +180,75 @@
                     <div><label for="message">Message:</label></div>
                     <input class="slds-form-element__control" id="message" type="text" name="message" value="">
                 </div>
+
+                <div id="form-error-banner" class="slds-notify slds-notify_alert slds-theme_alert-texture"
+                    style="display:none; margin-top:1rem;" role="alert">
+                    <span class="slds-assistive-text">Error</span>
+                    <span class="slds-icon_container slds-icon-utility-error" title="Error">
+                        <svg class="slds-icon slds-icon_x-small" aria-hidden="true">
+                            <use xlink:href="assets/icons/utility-sprite/svg/symbols.svg#error"></use>
+                        </svg>
+                    </span>
+                    <h2 id="form-error-text" style="margin:0 0 0 0.5rem; font-weight:600;"></h2>
+                </div>
+
+                <script type="text/javascript">
+                    (function () {
+                        const transactionInput = document.getElementById('transactionID');
+                        const errorBanner = document.getElementById('form-error-banner');
+                        const errorText = document.getElementById('form-error-text');
+
+                        function hideError() {
+                            errorBanner.style.display = 'none';
+                            errorText.textContent = '';
+                        }
+
+                        function showError(message) {
+                            errorText.textContent = message;
+                            errorBanner.style.display = 'flex';
+                        }
+
+                        function ensureTransactionId() {
+                            if (!transactionInput.value) {
+                                transactionInput.value = `txn-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+                            }
+                        }
+
+                        if (document.readyState === 'loading') {
+                            document.addEventListener('DOMContentLoaded', () => {
+                                ensureTransactionId();
+                                hideError();
+                            });
+                        } else {
+                            ensureTransactionId();
+                            hideError();
+                        }
+
+                        document.querySelectorAll('#campaignName, #tiny, #PE_ID, #TEMPLATE_ID, #TELEMARKETER_ID, #message')
+                            .forEach((input) => {
+                                input.addEventListener('blur', hideError);
+                                input.addEventListener('input', hideError);
+                            });
+
+                        // Validate required fields before SFMC reads them so that the user gets feedback early.
+                        document.getElementById('step1').addEventListener('focusout', (event) => {
+                            const target = event.target;
+                            if (target && target.id === 'TEMPLATE_ID' && !target.value.trim()) {
+                                showError('Template ID is required before the activity can be saved.');
+                            }
+                        });
+
+                        // In case the user clears the field manually we will re-seed it on blur.
+                        transactionInput.addEventListener('blur', ensureTransactionId);
+
+                        // Expose helper for integration tests (optional)
+                        window.__activityForm = {
+                            ensureTransactionId,
+                            showError,
+                            hideError
+                        };
+                    })();
+                </script>
 
                 <script type="text/javascript" src="main.js"></script>
 </body>

--- a/lib/activity-validation.js
+++ b/lib/activity-validation.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const uuid = require('uuid');
+
+class ValidationError extends Error {
+  constructor(message, details = []) {
+    super(message);
+    this.name = 'ValidationError';
+    this.details = details;
+    this.statusCode = 400;
+  }
+}
+
+function normalizeString(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  return String(value).trim();
+}
+
+function parseInArguments(body) {
+  if (!body || typeof body !== 'object') {
+    throw new ValidationError('Request body must be a JSON object.');
+  }
+
+  const { inArguments } = body;
+  if (!Array.isArray(inArguments) || inArguments.length === 0) {
+    throw new ValidationError('inArguments is required and must be a non-empty array.');
+  }
+
+  const args = inArguments[0];
+  if (!args || typeof args !== 'object') {
+    throw new ValidationError('The first element in inArguments must be an object.');
+  }
+
+  return args;
+}
+
+function validateTinyValue(value) {
+  const normalized = normalizeString(value);
+  if (normalized === '') {
+    return { value: normalized, error: 'tiny is required.' };
+  }
+  if (!['0', '1'].includes(normalized)) {
+    return { value: normalized, error: 'tiny must be either "0" or "1".' };
+  }
+  return { value: normalized, error: null };
+}
+
+function validateRequiredField(fieldName, value) {
+  const normalized = normalizeString(value);
+  if (normalized === '') {
+    return { value: normalized, error: `${fieldName} is required.` };
+  }
+  return { value: normalized, error: null };
+}
+
+function validateExecuteRequest(body) {
+  const args = parseInArguments(body);
+  const errors = [];
+
+  const { value: campaignName, error: campaignError } = validateRequiredField('campaignName', args.campaignName);
+  if (campaignError) errors.push(campaignError);
+
+  const tinyResult = validateTinyValue(args.tiny);
+  if (tinyResult.error) errors.push(tinyResult.error);
+
+  const { value: peId, error: peError } = validateRequiredField('PE_ID', args.PE_ID);
+  if (peError) errors.push(peError);
+
+  const { value: templateId, error: templateError } = validateRequiredField('TEMPLATE_ID', args.TEMPLATE_ID);
+  if (templateError) errors.push(templateError);
+
+  const { value: telemarketerId, error: telemarketerError } = validateRequiredField('TELEMARKETER_ID', args.TELEMARKETER_ID);
+  if (telemarketerError) errors.push(telemarketerError);
+
+  const { value: message, error: messageError } = validateRequiredField('message', args.message);
+  if (messageError) errors.push(messageError);
+
+  let transactionID = normalizeString(args.transactionID);
+  if (!transactionID) {
+    transactionID = uuid.v4();
+  }
+
+  if (errors.length > 0) {
+    throw new ValidationError('Invalid execute payload.', errors);
+  }
+
+  return {
+    transactionID,
+    campaignName,
+    tiny: tinyResult.value,
+    PE_ID: peId,
+    TEMPLATE_ID: templateId,
+    TELEMARKETER_ID: telemarketerId,
+    message,
+    rawArguments: args
+  };
+}
+
+module.exports = {
+  ValidationError,
+  validateExecuteRequest,
+  normalizeString
+};

--- a/lib/digo-client.js
+++ b/lib/digo-client.js
@@ -1,0 +1,109 @@
+'use strict';
+
+const axios = require('axios');
+const logger = require('./logger');
+
+class ProviderRequestError extends Error {
+  constructor(message, statusCode, details) {
+    super(message);
+    this.name = 'ProviderRequestError';
+    this.statusCode = statusCode;
+    this.details = details;
+  }
+}
+
+function getConfig() {
+  return {
+    url: process.env.DIGO_API_URL || 'https://engage-api.digo.link/notify',
+    xAuthorization: process.env.DIGO_X_AUTHORIZATION,
+    bearerToken: process.env.DIGO_BEARER_TOKEN,
+    timeout: Number(process.env.DIGO_HTTP_TIMEOUT_MS || 15000),
+    retryAttempts: Number(process.env.DIGO_RETRY_ATTEMPTS || 3),
+    retryBackoffMs: Number(process.env.DIGO_RETRY_BACKOFF_MS || 500),
+    stubResponses: process.env.DIGO_STUB_MODE === 'true'
+  };
+}
+
+function buildHeaders(config) {
+  const headers = {
+    'Content-Type': 'application/json'
+  };
+  if (config.xAuthorization) {
+    headers['X-Authorization'] = config.xAuthorization;
+  }
+  if (config.bearerToken) {
+    headers.Authorization = `Bearer ${config.bearerToken}`;
+  }
+  return headers;
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function sendPayloadWithRetry(payload, options = {}) {
+  const config = getConfig();
+  const attempts = options.retryAttempts || config.retryAttempts;
+  const backoffMs = options.retryBackoffMs || config.retryBackoffMs;
+  const client = options.httpClient || axios;
+  const headers = { ...buildHeaders(config), ...(options.headers || {}) };
+
+  if (config.stubResponses) {
+    logger.info('DIGO_STUB_MODE enabled, skipping outbound request.', { payloadSize: JSON.stringify(payload).length });
+    return {
+      status: 200,
+      data: {
+        stubbed: true,
+        message: 'Stub mode enabled - payload not sent.',
+        echoedPayload: payload
+      }
+    };
+  }
+
+  let attempt = 0;
+  let lastError;
+
+  while (attempt < attempts) {
+    attempt += 1;
+    try {
+      logger.info('Sending payload to DIGO provider.', { attempt, attempts });
+      const response = await client.post(config.url, payload, {
+        headers,
+        timeout: config.timeout
+      });
+
+      if (response.status >= 200 && response.status < 300) {
+        logger.info('Provider call succeeded.', { status: response.status });
+        return response;
+      }
+
+      lastError = new ProviderRequestError('Unexpected provider response status.', response.status, {
+        responseBody: response.data
+      });
+    } catch (error) {
+      const status = error.response ? error.response.status : undefined;
+      const shouldRetry = !status || status >= 500;
+      const details = {
+        status,
+        message: error.message,
+        responseBody: error.response ? error.response.data : undefined
+      };
+      lastError = new ProviderRequestError('Failed to send payload to provider.', status, details);
+      logger.warn('Provider call failed.', { attempt, attempts, details });
+      if (!shouldRetry || attempt >= attempts) {
+        break;
+      }
+      const waitMs = backoffMs * Math.pow(2, attempt - 1);
+      logger.info('Retrying provider call after backoff.', { waitMs });
+      await delay(waitMs);
+    }
+  }
+
+  throw lastError;
+}
+
+module.exports = {
+  sendPayloadWithRetry,
+  ProviderRequestError,
+  getConfig
+};

--- a/lib/digo-payload.js
+++ b/lib/digo-payload.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const { normalizeString, ValidationError } = require('./activity-validation');
+
+function resolveDataset(message, overrides) {
+  if (Array.isArray(overrides) && overrides.length > 0) {
+    return overrides
+      .map((item) => ({
+        msisdn: normalizeString(item.msisdn || item),
+        message: normalizeString(item.message || message)
+      }))
+      .filter((item) => item.msisdn !== '');
+  }
+
+  const defaultList = (process.env.DIGO_DEFAULT_MSISDNS || '')
+    .split(',')
+    .map((entry) => normalizeString(entry))
+    .filter((entry) => entry !== '');
+
+  if (defaultList.length === 0) {
+    throw new ValidationError('No recipients were provided for the SMS payload.', [
+      'Provide a dataSet array in the Journey Builder activity or configure DIGO_DEFAULT_MSISDNS.'
+    ]);
+  }
+
+  return defaultList.map((msisdn) => ({ msisdn, message }));
+}
+
+function buildDigoPayload(args, options = {}) {
+  const { message, transactionID, campaignName, tiny, PE_ID, TEMPLATE_ID, TELEMARKETER_ID } = args;
+  const { dataSetOverride } = options;
+
+  const dataset = resolveDataset(message, dataSetOverride || args.dataSet);
+
+  return {
+    transactionID,
+    campaignName,
+    oa: process.env.DIGO_ORIGINATOR || 'TACMPN',
+    channel: 'sms',
+    tiny,
+    tlv: {
+      PE_ID,
+      TEMPLATE_ID,
+      TELEMARKETER_ID
+    },
+    dataSet: dataset
+  };
+}
+
+module.exports = {
+  buildDigoPayload,
+  resolveDataset
+};

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const LEVEL_PRIORITY = { debug: 10, info: 20, warn: 30, error: 40 };
+const DEFAULT_LEVEL = process.env.LOG_LEVEL ? process.env.LOG_LEVEL.toLowerCase() : 'info';
+const DEFAULT_PRIORITY = LEVEL_PRIORITY[DEFAULT_LEVEL] || LEVEL_PRIORITY.info;
+
+function formatMeta(meta = {}) {
+  if (!meta || typeof meta !== 'object' || Object.keys(meta).length === 0) {
+    return '';
+  }
+  try {
+    return ` | meta=${JSON.stringify(meta)}`;
+  } catch (error) {
+    return ` | meta_unserializable=${error.message}`;
+  }
+}
+
+function log(level, message, meta) {
+  if (LEVEL_PRIORITY[level] < DEFAULT_PRIORITY) {
+    return;
+  }
+  const timestamp = new Date().toISOString();
+  const formattedMeta = formatMeta(meta);
+  const line = `[${timestamp}] [${level.toUpperCase()}] ${message}${formattedMeta}`;
+  if (level === 'error') {
+    console.error(line);
+  } else if (level === 'warn') {
+    console.warn(line);
+  } else {
+    console.log(line);
+  }
+}
+
+module.exports = {
+  debug(message, meta) {
+    log('debug', message, meta);
+  },
+  info(message, meta) {
+    log('info', message, meta);
+  },
+  warn(message, meta) {
+    log('warn', message, meta);
+  },
+  error(message, meta) {
+    log('error', message, meta);
+  }
+};

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "express": "^4.17.2",
     "https": "^1.0.0",
     "jekyll": "^3.0.0-beta1",
-    "postmonger": "0.0.16",
-    "request": "^2.88.2"
+    "postmonger": "0.0.16"
   },
   "devDependencies": {
     "babel-core": "^4.7.16",


### PR DESCRIPTION
## Summary
- add a dedicated validation layer and retrying provider client for executeV2 requests
- expose activity assets (icon, config endpoints) from the local host and document the exact payload Journey Builder must send
- harden the configuration UI by restoring the transaction field, auto-generating IDs, and surfacing inline validation messaging

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d6750a28148330858fca1485b4a744