### PR TITLE
Add explicit uuid dependency for server startup

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,7 +12,7 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const path = require('path');
 const configJSON = require('./config-json');
-const uuid = require('uuid');
+const { v4: uuidv4 } = require('uuid');
 const logger = require('./lib/logger');
 const { ValidationError, validateExecuteRequest } = require('./lib/activity-validation');
 const { buildDigoPayload } = require('./lib/digo-payload');
@@ -34,7 +34,7 @@ app.use('/images', express.static(path.join(__dirname, 'images')));
 
 // Attach a correlation id for every request so that logs are traceable.
 app.use((req, res, next) => {
-  const correlationId = req.headers['x-correlation-id'] || uuid.v4();
+  const correlationId = req.headers['x-correlation-id'] || uuidv4();
   req.correlationId = correlationId;
   res.set('X-Correlation-Id', correlationId);
   next();

--- a/lib/activity-validation.js
+++ b/lib/activity-validation.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const uuid = require('uuid');
+const { v4: uuidv4 } = require('uuid');
 
 class ValidationError extends Error {
   constructor(message, details = []) {
@@ -79,7 +79,7 @@ function validateExecuteRequest(body) {
 
   let transactionID = normalizeString(args.transactionID);
   if (!transactionID) {
-    transactionID = uuid.v4();
+    transactionID = uuidv4();
   }
 
   if (errors.length > 0) {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "express": "^4.17.2",
     "https": "^1.0.0",
     "jekyll": "^3.0.0-beta1",
-    "postmonger": "0.0.16"
+    "postmonger": "0.0.16",
+    "uuid": "^3.4.0"
   },
   "devDependencies": {
     "babel-core": "^4.7.16",


### PR DESCRIPTION
## Summary
- add the missing uuid dependency so the activity server can start reliably in production
- update the activity and validation modules to use the shared uuid helper

## Testing
- npm start
- curl -i http://localhost:3001/health

------
https://chatgpt.com/codex/tasks/task_e_68d686b675e883308fa29c35b94d8048