### PR TITLE
Improve proxy awareness for config endpoints

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,6 +19,7 @@ const { buildDigoPayload } = require('./lib/digo-payload');
 const { sendPayloadWithRetry, ProviderRequestError } = require('./lib/digo-client');
 
 const app = express();
+app.set('trust proxy', true);
 
 const designSystemAssetsPath = path.join(
   __dirname,

--- a/config-json.js
+++ b/config-json.js
@@ -12,10 +12,29 @@ function resolveBaseUrl(req) {
   if (process.env.PUBLIC_BASE_URL) {
     return process.env.PUBLIC_BASE_URL;
   }
-  if (!req || !req.protocol || !req.get) {
+
+  if (!req || typeof req.get !== 'function') {
     return '';
   }
-  return `${req.protocol}://${req.get('host')}`;
+
+  const forwardedProto = req.get('x-forwarded-proto');
+  let protocol = forwardedProto ? forwardedProto.split(',')[0].trim() : '';
+
+  if (!protocol && req.protocol) {
+    protocol = req.protocol;
+  }
+
+  if (!protocol) {
+    return '';
+  }
+
+  const host = req.get('host');
+
+  if (!host) {
+    return '';
+  }
+
+  return `${protocol}://${host}`;
 }
 
 module.exports = function configJSON(req) {


### PR DESCRIPTION
## Summary
- enable Express trust proxy so req.protocol respects x-forwarded-proto when behind TLS termination
- enhance config base URL resolution to prefer forwarded proto headers and build HTTPS URLs as expected

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d68d1f46848330be13ea65e24019bd