### PR TITLE
Add documentation for SFMC custom activity files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,103 @@
-# Salesforce Marketing Cloud Journey Builder - Custom Activity Example
-This repository aims to instruct beginners on how to create custom activities in Marketing Cloud. The walkthrough guide can be found here: [https://balwillsfdc.github.io/sfmc-my-custom-acitivty/](https://balwillsfdc.github.io/sfmc-my-custom-acitivty/) The requirements for building your own custom JB activity are as follows: 
-- Javascript / Node.js knowledge
-- Marketing Cloud Journey Builder Expertise
-- Marketing Cloud Account
-- Heroku Account
+# SFMC Custom SMS Send Activity
 
-## Deploy to Heroku
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?https://github.com/balwillSFDC/sfmc-my-custom-acitivty)
+## Overview
+This repository contains a Salesforce Marketing Cloud (SFMC) Journey Builder custom activity that collects SMS delivery parameters inside the configuration canvas and forwards them to an external SMS orchestration API during journey execution. The project bundles a lightweight Express server for hosting the activity assets, the client-side Journey Builder integration built with Postmonger, and the supporting configuration metadata required by SFMC.
 
-# Notes
-- For additional examples/documentation on Salesforce Marketing Cloud Custom Activities check the [github](https://github.com/salesforce-marketingcloud/sfmc-example-jb-custom-activity) and [documentation](https://developer.salesforce.com/docs/marketing/marketing-cloud/guide/creating-activities.html)
-## Postman Collection
-A Postman collection covering every HTTP endpoint exposed by `app.js` is available at `postman/sfmc-custom-activity.postman_collection.json`. Import it into Postman and update the `baseUrl` variable to match your deployment host before sending requests.
+## Architecture
+```
++--------------------+        +---------------------------+        +--------------------------------+
+| Journey Builder UI |<------>| Front-end (src/index.js) |<------>| Express Server (app.js)        |
+| (iframe)           |  PM    |  • Renders configuration |  HTTP  |  • Serves static assets       |
+|                    | events |  • Emits Postmonger msgs |  REST  |  • Hosts REST endpoints       |
++--------------------+        +---------------------------+        +--------------------------------+
+                                                                   |                                |
+                                                                   |  Execution webhook (/executeV2)|
+                                                                   +----------------+---------------+
+                                                                                    |
+                                                                                    v
+                                                                  External SMS orchestration API
+```
+* **Postmonger (PM)** events bridge the Journey Builder iframe with the activity configuration UI.
+* The Express server exposes the SFMC lifecycle endpoints (`/save`, `/publish`, `/validate`, `/stop`) and the execution webhook (`/executeV2`).
+* `config-json.js` dynamically generates the `config.json` contract consumed by Journey Builder to install the activity.
+
+## Getting Started
+
+### Prerequisites
+* Node.js 16.x or later
+* npm 8.x or later
+* SFMC account with Journey Builder admin permissions (for deployment and testing)
+
+### Installation
+```bash
+npm install
+```
+
+### Local Development
+1. Run the local server and webpack watcher:
+   ```bash
+   npm run dev
+   ```
+   * `npm start` serves the Express app on `http://localhost:3001`.
+   * `webpack --watch` rebundles `src/index.js` into `main.js` when client code changes.
+2. Open `http://localhost:3001` in a browser to load the configuration UI.
+3. Use the in-browser test harness (`window.jb.ready()`) to simulate Journey Builder events during development.
+
+### Build
+The project relies on webpack to produce `main.js`. A one-off production bundle can be generated with:
+```bash
+npx webpack --mode production
+```
+
+### Testing
+Automated tests are not defined. Validate functionality manually by triggering the Journey Builder simulator (see `setupExampleTestHarness` in `src/index.js`) or by connecting the activity to a sandbox Journey.
+
+## Environment Configuration
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `PORT` | `3001` | Express server listening port. |
+| `SFMC_BASE_URL` | _not set_ | Optionally override the hostname used in `config-json.js` if hosting endpoints under a different domain. Update the file accordingly when customizing. |
+| `LOG_LEVEL` | _not set_ | Implement custom logging controls in `app.js` if required (currently a simple console logger is used). |
+
+> **Security note:** `/executeV2` forwards SMS payloads to an external API using static credentials. Store these secrets in environment variables or a secure vault before deploying to production.
+
+## Deployment
+* The repository ships with a Heroku-compatible `Procfile` and `app.json`. Deploy to Heroku via `heroku create` followed by `git push heroku main`.
+* Ensure that HTTPS endpoints (`/config.json`, `/save`, `/publish`, `/validate`, `/stop`, `/executeV2`) are publicly accessible for SFMC.
+* Update `config-json.js` to reference the deployed domain so Journey Builder resolves the correct URLs.
+* Configure firewall rules to allow inbound requests from SFMC IP ranges and outbound traffic to the external SMS API.
+
+## Documentation Index
+The following guides describe each source file in detail:
+
+- [app.js](docs/files/app.js.md)
+- [app.json](docs/files/app.json.md)
+- [config-json.js](docs/files/config-json.js.md)
+- [index.html](docs/files/index.html.md)
+- [main.js](docs/files/main.js.md)
+- [package.json](docs/files/package.json.md)
+- [Procfile](docs/files/Procfile.md)
+- [src/index.js](docs/files/src/index.js.md)
+- [webpack.config.js](docs/files/webpack.config.js.md)
+
+## Troubleshooting
+| Symptom | Possible Cause | Suggested Action |
+| --- | --- | --- |
+| Journey Builder cannot load the activity | `config.json` unreachable or misconfigured domain | Verify hosting URL and inspect Express logs for the `/config.json` request. |
+| `Done` button remains disabled | Required field missing or Postmonger event not firing | Check browser console for validation warnings and ensure `FIELD_DEFINITIONS` match DOM element IDs. |
+| `/executeV2` returns 500 | External SMS API failure or missing credentials | Review server logs, confirm API key validity, and inspect the response body logged in `app.js`. |
+| Activity fails during Journey activation | Lifecycle endpoint returns non-200 | Validate `/publish` and `/validate` endpoints respond successfully and review SFMC Journey Builder error logs. |
+
+Log sources:
+* Server: terminal running `npm start` (Express logs and outbound API payloads).
+* Browser: Developer tools console for Postmonger event traces and validation messages.
+* SFMC: Journey Builder error dialog and Interaction logs.
+
+## Glossary
+* **Custom Activity** – A pluggable Journey Builder node that executes custom logic during a contact’s path.
+* **Journey Builder** – SFMC module for designing customer journeys with activities, decision splits, and waits.
+* **Postmonger** – Lightweight message bus used by Journey Builder to communicate with iframe-based activities.
+* **In Arguments** – Data payload configured for an activity and delivered during execution.
+* **Out Arguments** – Data returned by an activity to Journey Builder (unused in this solution).
+* **Execution Webhook** – The HTTP endpoint invoked by SFMC for each contact passing through the activity.
+* **Activity Lifecycle Endpoints** – REST endpoints (`/save`, `/publish`, `/validate`, `/stop`) called by SFMC during activity management phases.

--- a/docs/files/Procfile.md
+++ b/docs/files/Procfile.md
@@ -1,0 +1,45 @@
+# Procfile
+
+## Role in the System
+Defines the process type and command used by Heroku (or other Procfile-based platforms) to run the Express server in production.
+
+## Public Interface
+| Entry | Description |
+| --- | --- |
+| `web: node app.js` | Declares a single web dyno that starts the Express application by executing `node app.js`. |
+
+## Key Parameters and Return Values
+Not applicable; the Procfile is declarative.
+
+## External Dependencies
+* Relies on the Heroku runtime (or compatible orchestrators) to interpret the Procfile and manage processes.
+
+## Data Flow
+Controls how incoming HTTP traffic is routed to the Node.js process defined in `app.js` when deployed to Heroku.
+
+## Error Handling and Edge Cases
+* If `app.js` fails to start, the dyno will crash and automatically restart; inspect Heroku logs for stack traces.
+* Ensure environment variables required by `app.js` (e.g., `PORT`) are configured in the hosting platform.
+
+## Usage Example
+Deploying to Heroku automatically detects the Procfile:
+```bash
+heroku create
+git push heroku main
+heroku logs --tail
+```
+
+## Related Files
+* `app.js` – Script executed by the Procfile.
+* `app.json` – Describes the app for Heroku review apps or the platform API.
+
+## Troubleshooting
+| Issue | Resolution |
+| --- | --- |
+| Deployment boots but no web process | Confirm the Procfile is committed at the repository root. |
+| Dyno crashes repeatedly | Run `heroku logs --tail` to inspect runtime errors from `app.js`. |
+| Application bound to wrong port | Ensure the code reads `process.env.PORT` (already handled in `app.js`). |
+
+## Glossary
+* **Dyno** – Heroku container that runs a command defined in the Procfile.
+* **Web Process** – Process type that listens for HTTP requests in Heroku.

--- a/docs/files/app.js.md
+++ b/docs/files/app.js.md
@@ -1,0 +1,78 @@
+# app.js
+
+## Role in the System
+Primary Express server responsible for hosting the custom activity assets and exposing the REST endpoints Salesforce Marketing Cloud invokes during the Journey Builder lifecycle and execution phases.
+
+## Public Interface
+| Endpoint / Function | Description |
+| --- | --- |
+| `app.get('/')`, `app.get('/index.html')`, `app.get('/main.js')`, `app.get('/main.js.map')` | Serve the static configuration UI bundle. |
+| `app.get('/config.json')` | Returns the dynamically generated activity manifest by invoking `configJSON(req)`. |
+| `app.post('/save')` | Acknowledges configuration saves with HTTP 200. |
+| `app.post('/publish')` | Confirms Journey activation with HTTP 200. |
+| `app.post('/validate')` | Allows Journey Builder to validate the configuration; returns HTTP 200 when valid. |
+| `app.post('/stop')` | Handles Journey stop events; currently returns HTTP 200 with no side-effects. |
+| `app.post('/executeV2')` | Core execution webhook that constructs the SMS payload, logs requests, and forwards them to the external API. |
+| `app.get('/health')` | Lightweight health check returning `Server is up and running`. |
+| `app.listen(PORT)` | Boots the HTTP server. |
+
+## Key Parameters and Return Values
+| Function | Parameters | Returns | Notes |
+| --- | --- | --- | --- |
+| `configJSON(req)` | `req` (`express.Request`) | `object` | Imported from `config-json.js`; builds `config.json`. |
+| `app.post('/executeV2')` | `req.body` (`object` with `inArguments`, `keyValue`) | `res.json()` result | Generates `transactionID` via `uuid`, constructs payload, and relays to `https://engage-api.digo.link/notify`. |
+| `request(options, callback)` | Options include `method`, `url`, `headers`, `json` payload | HTTP response handled in callback | On error, responds with status 500 and `{ errorMessage }`. On success, echoes downstream response in `{ message: body }`. |
+
+## External Dependencies
+* `express` – Web framework for routing and static file serving.
+* `body-parser` – JSON body parsing middleware.
+* `request` – Sends outbound HTTP POST to the SMS API.
+* `uuid` – Generates unique transaction IDs.
+* `axios` and `https` – Present but not actively used; candidates for cleanup.
+* `@salesforce-ux/design-system` – Static assets served from `/assets` for styling.
+
+## Data Flow
+* **Inputs:** Journey Builder requests for lifecycle routes, execution payloads containing `inArguments`, `keyValue`, and contact data.
+* **Outputs:** HTTP status codes to SFMC; on execution, forwards structured JSON to the external SMS orchestration API and returns its response to SFMC.
+* **Data Extensions:** Execution payload can include Data Extension substitutions; values arrive via `inArguments` processed in `/executeV2`.
+
+## Error Handling and Edge Cases
+* Wraps `/executeV2` in a `try/catch` to handle synchronous failures.
+* Returns HTTP 500 with `errorMessage` when outbound request errors or required inputs are missing.
+* Logs incoming payloads and downstream responses for observability; consider integrating a structured logger for production.
+
+## Usage Example
+Trigger the execution endpoint manually during development:
+```bash
+curl -X POST http://localhost:3001/executeV2 \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "inArguments": [{
+      "campaignName": "Sample",
+      "tiny": "1",
+      "PE_ID": "12345",
+      "TEMPLATE_ID": "67890",
+      "TELEMARKETER_ID": "TM-001",
+      "message": "Test SMS"
+    }],
+    "keyValue": "CONTACT-001"
+  }'
+```
+
+## Related Files
+* `config-json.js` – Supplies configuration metadata consumed by `/config.json`.
+* `index.html` & `main.js` – Static assets served through Express.
+* `Procfile` – Defines the production process that runs `node app.js`.
+
+## Troubleshooting
+| Issue | Resolution |
+| --- | --- |
+| Lifecycle endpoints returning 404 | Confirm the Express server is running and that SFMC endpoints point to the correct host. |
+| `/executeV2` fails with missing arguments | Validate the activity configuration maps form fields into `inArguments`. |
+| External API call returns 401 | Replace hard-coded credentials with environment variables containing valid API keys. |
+| Static assets not loading | Ensure webpack built `main.js` and that `/assets` path resolves to the Salesforce Lightning Design System distribution. |
+
+## Glossary
+* **Lifecycle Endpoint** – API called by Journey Builder during save, publish, validate, and stop phases.
+* **Execution Mode** – Determines how SFMC invokes the activity (real-time vs. testing); available via `req.body`. |
+* **Contact Key** – Unique identifier for a contact, found in `req.body.keyValue`.

--- a/docs/files/app.json.md
+++ b/docs/files/app.json.md
@@ -1,0 +1,41 @@
+# app.json
+
+## Role in the System
+Describes the application for Heroku’s App Manifest specification, enabling one-click deployments and review apps with predefined metadata and buildpacks.
+
+## Public Interface
+| Field | Description |
+| --- | --- |
+| `name`, `description` | Human-readable details shown in Heroku dashboards or the Elements marketplace. |
+| `repository` | Points to the GitHub repository containing the source code. |
+| `keywords` | Tags that describe the application domain. |
+| `buildpacks` | Specifies `heroku/nodejs` to build the Node.js application. |
+
+## Key Parameters and Return Values
+Not applicable; JSON metadata consumed by the Heroku platform.
+
+## External Dependencies
+* Requires the Heroku platform to interpret the manifest when provisioning apps.
+
+## Data Flow
+Influences how Heroku sets up the runtime environment (Node.js buildpack) and documents the app in dashboards. Does not affect runtime execution directly.
+
+## Error Handling and Edge Cases
+* Ensure the repository URL remains accurate; otherwise, Heroku one-click deployments will fail.
+* Update the `keywords` and description as features evolve for clearer documentation.
+
+## Usage Example
+To deploy via the Heroku Platform API or the dashboard, supply `app.json` as part of the configuration when creating the app. No command-line invocation is required beyond standard Heroku workflows.
+
+## Related Files
+* `Procfile` – Defines the process executed after buildpack installation.
+* `package.json` – Provides scripts and dependencies resolved by the Node.js buildpack.
+
+## Troubleshooting
+| Issue | Resolution |
+| --- | --- |
+| Heroku one-click deploy fails | Verify the repository URL is accessible and contains a valid Node.js project. |
+| Buildpack mismatch errors | Confirm `heroku/nodejs` is still appropriate for the application runtime. |
+
+## Glossary
+* **App Manifest** – JSON file that describes an application’s configuration for automated provisioning on Heroku.

--- a/docs/files/config-json.js.md
+++ b/docs/files/config-json.js.md
@@ -1,0 +1,53 @@
+# config-json.js
+
+## Role in the System
+Exports a function that builds the `config.json` manifest consumed by Journey Builder when rendering and executing the custom activity. It defines metadata, schema, lifecycle endpoints, and execution settings.
+
+## Public Interface
+| Function | Description |
+| --- | --- |
+| `configJSON(req)` | Generates a configuration object tailored to the incoming request context (enables host-specific URLs if needed). |
+
+## Key Parameters and Return Values
+| Function | Parameters | Returns | Notes |
+| --- | --- | --- | --- |
+| `configJSON(req)` | `req` (`express.Request`) | `object` | Returns a JSON-serialisable object adhering to the Custom Activity schema, including metadata, arguments, and configuration endpoints. |
+
+## External Dependencies
+* None beyond Node.js runtime; the module exports a pure function.
+
+## Data Flow
+* **Inputs:** Optionally uses `req` to infer hostname or request headers if you customise the function.
+* **Outputs:** JSON describing the activity (icon paths, supported languages, execute endpoint, schema definitions, and lifecycle URLs).
+* **Data Extensions:** Defines schema metadata for fields such as `campaignName`, `tiny`, `PE_ID`, etc., which can be mapped to Data Extension attributes during configuration.
+
+## Error Handling and Edge Cases
+* No explicit error handling; ensure the returned object includes valid HTTPS URLs accessible to SFMC.
+* Update the `url` values when deploying to different environments to avoid Journey Builder load failures.
+
+## Usage Example
+Serve `config.json` via Express:
+```javascript
+const express = require('express');
+const configJSON = require('./config-json');
+
+app.get('/config.json', (req, res) => {
+  res.status(200).json(configJSON(req));
+});
+```
+
+## Related Files
+* `app.js` – Invokes `configJSON` to fulfil `/config.json` requests.
+* `index.html` / `main.js` – UI assets referenced by the manifest’s `icon` paths.
+* `src/index.js` – Uses the same field IDs defined under `schema.arguments.execute.inArguments`.
+
+## Troubleshooting
+| Issue | Resolution |
+| --- | --- |
+| Journey Builder cannot load the activity | Verify the manifest URLs (execute, save, publish, validate, stop) point to accessible HTTPS endpoints. |
+| Icons not displaying | Confirm the `images` directory is deployed and paths (`images/icon.svg`) are correct relative to the server root. |
+| Schema mismatches | Ensure the property IDs in `schema.arguments.execute.inArguments` match the UI field IDs and execution payload processing in `app.js`. |
+
+## Glossary
+* **Manifest** – The configuration contract that informs Journey Builder how to render and call the activity.
+* **Schema** – Describes the data types and visibility of fields exposed to the Journey configuration UI.

--- a/docs/files/index.html.md
+++ b/docs/files/index.html.md
@@ -1,0 +1,50 @@
+# index.html
+
+## Role in the System
+Defines the markup, styling, and asset references for the Journey Builder configuration iframe. Provides the form fields bound to the custom activity data model and loads the compiled JavaScript bundle.
+
+## Public Interface
+| Element / Section | Description |
+| --- | --- |
+| `<link href="assets/styles/salesforce-lightning-design-system.css">` | Imports Salesforce Lightning Design System for consistent styling. |
+| `.activity-wrapper` container | Main card layout wrapping the form elements. |
+| Form fields (`#campaignName`, `#tiny`, `#PE_ID`, `#TEMPLATE_ID`, `#TELEMARKETER_ID`, `#message`) | Input controls whose IDs map directly to `FIELD_DEFINITIONS` in `src/index.js`. |
+| `<script src="main.js">` | Loads the Postmonger integration logic bundled by webpack. |
+
+## Key Parameters and Return Values
+Not applicable; the document exposes DOM elements consumed by `main.js`.
+
+## External Dependencies
+* Salesforce Lightning Design System assets hosted locally under `/assets`.
+* Google Fonts (`Source Sans Pro`).
+* `main.js` bundle for behaviour.
+
+## Data Flow
+* **Inputs:** User-entered field values captured via the DOM.
+* **Outputs:** Values read by `src/index.js` and saved into `inArguments`.
+* **Data Extensions:** Input fields can be mapped to Data Extension attributes via Journey Builder configuration.
+
+## Error Handling and Edge Cases
+* Validation classes (`slds-has-error`) applied by `src/index.js` render error states.
+* Ensure element IDs remain stable; any changes require updates to `FIELD_DEFINITIONS` and schema definitions.
+
+## Usage Example
+To add an additional optional field:
+1. Duplicate one of the `<div class="form-field">` blocks with a new `id` and label.
+2. Update `FIELD_DEFINITIONS` in `src/index.js` and the schema in `config-json.js` to include the new field.
+
+## Related Files
+* `src/index.js` – Attaches event handlers and validation to the DOM elements.
+* `main.js` – Bundled script referenced at the bottom of the document.
+* `images/` – Contains assets referenced by the hero banner and manifest icons.
+
+## Troubleshooting
+| Issue | Resolution |
+| --- | --- |
+| Styles missing | Confirm `/assets/styles/salesforce-lightning-design-system.css` is accessible and that static serving is configured in `app.js`. |
+| Script not executing | Ensure webpack has produced `main.js` and that the `<script>` path is correct relative to the server root. |
+| Layout appears broken in Journey Builder | Validate the iframe width constraints and consider using responsive CSS to handle smaller viewports. |
+
+## Glossary
+* **Inspector** – The Journey Builder side panel (iframe) where the configuration UI is rendered.
+* **Lightning Design System** – Salesforce’s CSS framework used for consistent UI styling.

--- a/docs/files/main.js.md
+++ b/docs/files/main.js.md
@@ -1,0 +1,44 @@
+# main.js
+
+## Role in the System
+Webpack-generated bundle that packages the client-side logic from `src/index.js` (and dependencies) into a single script served to Journey Builder. This is the file referenced by `index.html`.
+
+## Public Interface
+The bundle exposes the same runtime behaviour as `src/index.js`, executed immediately in the browser context. No additional globals are exported beyond those intentionally attached to `window` (e.g., `window.jb` in development mode).
+
+## Key Parameters and Return Values
+Not directly authored; mirrors the functions described in [`src/index.js`](src/index.js.md). Each function operates on DOM elements and Postmonger sessions without exporting module-level APIs.
+
+## External Dependencies
+* Includes compiled versions of the `postmonger` library and any other modules imported by `src/index.js`.
+* Relies on the browser DOM, same as the source module.
+
+## Data Flow
+Identical to `src/index.js`: receives Journey Builder events via Postmonger, reads form values, and pushes configuration updates and execution payloads back to Journey Builder.
+
+## Error Handling and Edge Cases
+* Minified output can make debugging difficult; use source maps (`main.js.map`) during development for readable stack traces.
+* Ensure webpack rebuilds the bundle after changes to `src/index.js`; otherwise, the browser will continue running stale code.
+
+## Usage Example
+Include the bundle in the configuration page:
+```html
+<script src="main.js"></script>
+```
+During debugging, open browser DevTools with source maps enabled to inspect the original source code.
+
+## Related Files
+* `src/index.js` – Authoritative source module compiled into this file.
+* `main.js.map` – Source map linking the bundle to original source files.
+* `webpack.config.js` – Build configuration controlling bundle output.
+
+## Troubleshooting
+| Issue | Resolution |
+| --- | --- |
+| Console stack traces minified | Enable source maps in browser DevTools and ensure `devtool` is set to `cheap-source-map` (default in `webpack.config.js`). |
+| Bundle outdated after code change | Re-run `webpack --watch` or restart `npm run dev` to trigger a rebuild. |
+| File not served in production | Confirm the compiled `main.js` is deployed alongside `index.html` and that Express static routes are configured. |
+
+## Glossary
+* **Bundle** – Aggregated JavaScript file produced by a build tool such as webpack.
+* **Source Map** – Mapping file that correlates minified bundle code to original source for debugging. |

--- a/docs/files/package.json.md
+++ b/docs/files/package.json.md
@@ -1,0 +1,51 @@
+# package.json
+
+## Role in the System
+Defines project metadata, npm scripts, and dependency versions required to build and run the custom activity.
+
+## Public Interface
+| Field | Description |
+| --- | --- |
+| `name`, `version`, `description` | Metadata describing the npm package. |
+| `scripts.start` | Executes `node ./app.js` to launch the Express server. |
+| `scripts.dev` | Runs both `npm start` and `webpack --watch` concurrently for local development. |
+| `scripts.test` | Placeholder script returning an error (no automated tests defined). |
+| `dependencies` | Runtime packages required by the server or build (Express, Postmonger, request, etc.). |
+| `devDependencies` | Build tooling such as webpack and Babel presets. |
+
+## Key Parameters and Return Values
+Not applicable; JSON configuration consumed by npm and Node.js tooling.
+
+## External Dependencies
+* Runtime dependencies include `express`, `postmonger`, `request`, `axios`, `@salesforce-ux/design-system`, etc.
+* Development dependencies include `webpack`, `webpack-cli`, and Babel tooling.
+
+## Data Flow
+Controls which modules are installed in the deployment environment and determines available npm commands for build/run workflows.
+
+## Error Handling and Edge Cases
+* Missing dependencies will cause `npm install` to fail; ensure the listed versions exist on npm.
+* Update scripts cautiously to avoid breaking deployment automation (e.g., Heroku relies on `npm start`).
+
+## Usage Example
+Install dependencies and run the app:
+```bash
+npm install
+npm run dev
+```
+
+## Related Files
+* `app.js` – Entry point invoked by `npm start`.
+* `webpack.config.js` – Consumed by the `webpack --watch` script.
+* `Procfile` – Alternative process definition used in production deployments.
+
+## Troubleshooting
+| Issue | Resolution |
+| --- | --- |
+| `npm install` fails | Clear the lock file if inconsistent, update package versions, or ensure network access to npm registry. |
+| `npm run dev` exits immediately | Confirm `concurrently` is installed globally or replace with `npx concurrently`. |
+| Security vulnerabilities reported | Audit dependencies and upgrade to patched versions (consider replacing deprecated `request`). |
+
+## Glossary
+* **npm Script** – Named command defined in `package.json` executed via `npm run <script>`.
+* **Dependency** – Package required at runtime or build time by the application.

--- a/docs/files/src/index.js.md
+++ b/docs/files/src/index.js.md
@@ -1,0 +1,65 @@
+# src/index.js
+
+## Role in the System
+Client-side controller for the Journey Builder custom activity. It renders the configuration form inside the iframe, synchronises form state with Journey Builder via Postmonger events, validates inputs, and prepares the payload saved into `inArguments`.
+
+## Public Interface
+| Function | Description |
+| --- | --- |
+| `main()` | Bootstraps event listeners after DOM load, wires the Postmonger session, and optionally starts the local test harness. |
+| `onInitActivity(payload)` | Receives the activity definition from Journey Builder, hydrates the form, and sets the configuration status. |
+| `onDoneButtonClick()` | Validates fields, assembles `inArguments`, marks the activity as configured, and triggers `updateActivity`. |
+| `onCancelButtonClick()` | Signals Journey Builder to close the inspector without saving changes. |
+| `onFormEntry(event)` | Marks the activity dirty whenever a field is edited. |
+| `setupExampleTestHarness()` | Creates a mock Postmonger session to emulate Journey Builder interactions locally. |
+| Helper utilities | `setFieldValue`, `getFieldValue`, `showFieldError`, `clearFieldError`, and `getFieldContainer` manage DOM interactions and validation state. |
+
+## Key Parameters and Return Values
+| Function | Parameters | Returns | Notes |
+| --- | --- | --- | --- |
+| `onInitActivity(payload)` | `payload` (`object`): Full activity definition from Journey Builder. | `void` | Extracts `arguments.execute.inArguments` to prefill fields. |
+| `onDoneButtonClick()` | _None_ | `void` | Builds `fieldPayload` object keyed by `FIELD_DEFINITIONS`. Triggers `updateActivity`. |
+| `onFormEntry(event)` | `event.target` (`HTMLInputElement \| HTMLSelectElement`) | `void` | Uses `connection.trigger('setActivityDirtyState', true)` when value is non-empty. |
+| `setFieldValue(id, value)` | `id` (`string`), `value` (`string \| number \| null`) | `void` | Handles both `<input>` and `<select>` elements. |
+| `getFieldValue(field)` | `field` (`HTMLElement`) | `string` | Trims string values and normalises selects. |
+| `setupExampleTestHarness()` | _None_ | `void` | Exposes `window.jb` with `ready()` and `save()` helpers for development. |
+
+## External Dependencies
+* [`postmonger`](https://github.com/salesforce-marketingcloud/postmonger) – facilitates communication with Journey Builder.
+* Browser DOM APIs – used for event binding, querying, and validation visuals.
+
+## Data Flow
+* **Inputs:** Activity payload from Journey Builder (includes `inArguments` values) and user input from HTML fields.
+* **Outputs:** Updated `activity.arguments.execute.inArguments` array posted back to Journey Builder via `updateActivity`.
+* **Data Extensions:** None referenced directly. Fields can be bound to Data Extension attributes during configuration.
+
+## Error Handling and Edge Cases
+* Missing DOM elements trigger console warnings and skip event binding.
+* Validation prevents saving when required fields are empty by showing inline errors and halting `updateActivity`.
+* Defensive checks ensure `inArguments` arrays exist before merging to avoid runtime errors.
+
+## Usage Example
+Populate the form programmatically during testing:
+```javascript
+// In the browser console while running npm run dev
+setFieldValue('campaignName', 'Preview Campaign');
+setFieldValue('message', 'Test SMS copy');
+onDoneButtonClick(); // Triggers updateActivity with the populated payload
+```
+
+## Related Files
+* `index.html` – Declares the markup and element IDs consumed by the script.
+* `main.js` – Webpack-bundled version served in production.
+* `config-json.js` – Ensures the field identifiers align with Journey Builder schema.
+
+## Troubleshooting
+| Issue | Resolution |
+| --- | --- |
+| Form values do not persist when reopening | Confirm the Journey Builder payload includes the same IDs defined in `FIELD_DEFINITIONS`. |
+| `window.jb` is undefined during local testing | Ensure `isDev` resolves to `true` (application served from `localhost` or `127.0.0.1`). |
+| `updateActivity` not firing | Check that `connection.trigger('ready')` executed and that Journey Builder responded with `initActivity`. |
+
+## Glossary
+* **Activity Payload** – JSON object Journey Builder shares with the activity, containing metadata and arguments.
+* **Dirty State** – Journey Builder flag that indicates unsaved configuration changes.
+* **In Arguments** – Runtime parameters passed to the execution webhook.

--- a/docs/files/webpack.config.js.md
+++ b/docs/files/webpack.config.js.md
@@ -1,0 +1,57 @@
+# webpack.config.js
+
+## Role in the System
+Configures webpack to bundle the client-side source from `src/index.js` into `main.js` with source maps for debugging.
+
+## Public Interface
+| Export | Description |
+| --- | --- |
+| `module.exports = (env, argv) => ({ ... })` | Function that receives webpack CLI arguments and returns the configuration object. |
+
+## Key Parameters and Return Values
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `env` | `object` | Optional environment variables passed from the CLI (unused currently). |
+| `argv.mode` | `string` | Determines whether the build runs in `development` or `production`. Sets `mode` property accordingly. |
+
+Returned configuration fields:
+* `mode` – Derived from `argv.mode`.
+* `devtool` – Uses `'cheap-source-map'` to generate source maps.
+* `entry` – Points to `./src/index.js`.
+* `output.path` – Emits bundles into the repository root.
+* `output.filename` – Outputs `main.js`.
+
+## External Dependencies
+* `path` – Node.js module for resolving filesystem paths.
+* `copy-webpack-plugin` – Imported but currently commented out (intended to copy Lightning Design System assets).
+
+## Data Flow
+Defines how source files are transformed into production-ready assets. Takes `src/index.js` as input and outputs `main.js` (+ optional assets when plugins are enabled).
+
+## Error Handling and Edge Cases
+* If `argv.mode` is undefined, webpack defaults to development mode.
+* Commented `CopyPlugin` section indicates prior asset-copying functionality; re-enable and configure patterns if static assets need to be copied to `dist/`.
+
+## Usage Example
+Run webpack in production mode:
+```bash
+npx webpack --mode production
+```
+
+Enable the copy plugin by uncommenting the `plugins` block and adjusting paths to match the desired output directory.
+
+## Related Files
+* `src/index.js` – Entry file compiled by webpack.
+* `main.js` – Output bundle consumed by the UI.
+* `package.json` – Provides `webpack` scripts and dependency declarations.
+
+## Troubleshooting
+| Issue | Resolution |
+| --- | --- |
+| Bundle missing | Ensure the `entry` path exists and that webpack has permission to write to the output directory. |
+| Source maps not loading | Confirm `devtool` remains enabled and that browsers can fetch `main.js.map`. |
+| Lightning Design System assets absent | Re-enable `CopyPlugin` or copy assets manually into the deployment package. |
+
+## Glossary
+* **Webpack** – Module bundler for JavaScript applications.
+* **Source Map** – File that maps compiled code back to original source for debugging.


### PR DESCRIPTION
## Summary
- rewrite the root README with architecture overview, setup instructions, troubleshooting guidance, and glossary
- add per-file documentation under docs/files covering server, client, build, and deployment assets with interfaces and usage notes

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68da0fe3c0c08330b8b35ceddddc808d