### PR TITLE
Switch provider auth to Basic credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,8 @@ The server listens on `http://localhost:3001` by default. For Journey Builder in
 | `PUBLIC_BASE_URL` | Fully qualified base URL used to generate config links (overrides proxy-derived host/protocol). |
 | `PORT` | Express listen port (defaults to `3001`). |
 | `LOG_LEVEL` | Minimum log level (`debug`, `info`, `warn`, `error`). Defaults to `info`. |
-| `DIGO_API_URL` | DIGO API endpoint (`https://engage-api.digo.link/notify` by default). |
-| `DIGO_X_AUTHORIZATION` | Optional `X-Authorization` header for DIGO authentication. |
-| `DIGO_BEARER_TOKEN` | Optional bearer token for DIGO authentication. |
+| `DIGO_API_URL` | Provider API endpoint (`https://sfmc.comsensetechnologies.com/api/message` by default). |
+| `COMSENSE_BASIC_AUTH` | Base64-encoded `username:password` string used for HTTP Basic authentication. |
 | `DIGO_HTTP_TIMEOUT_MS` | HTTP timeout in milliseconds (default `15000`). |
 | `DIGO_RETRY_ATTEMPTS` | Maximum retry attempts on transient errors (default `3`). |
 | `DIGO_RETRY_BACKOFF_MS` | Initial backoff delay in ms (default `500`, doubles per retry). |
@@ -95,7 +94,7 @@ The server listens on `http://localhost:3001` by default. For Journey Builder in
 | --- | --- |
 | Journey Builder inspector fails to load | Confirm `/config.json` responds with 200 and that `PUBLIC_BASE_URL` resolves correctly. Inspect browser console for Postmonger errors. |
 | `/executeV2` returns `status: 'invalid'` | Review the JSON response `details` array and ensure Journey data extensions map required fields. Logs include correlation IDs for tracing. |
-| Provider request failures | Validate DIGO credentials and network reachability. When `DIGO_STUB_MODE` is `true`, outbound calls are skipped. |
+| Provider request failures | Validate provider credentials (e.g., `COMSENSE_BASIC_AUTH`) and network reachability. When `DIGO_STUB_MODE` is `true`, outbound calls are skipped. |
 | Missing SMS recipients | Provide `dataSet` in Journey mappings or configure `DIGO_DEFAULT_MSISDNS`. |
 | Logs not appearing | Check `LOG_LEVEL` and your hosting platform's log drain or console. |
 

--- a/docs/files/lib/digo-client.js.md
+++ b/docs/files/lib/digo-client.js.md
@@ -26,9 +26,8 @@ Handles outbound HTTP communication with the DIGO SMS provider, adding retry log
 * `axios` for HTTP requests (can be replaced via `options.httpClient`).
 * `./logger` for trace logging.
 * Environment variables read by `getConfig()`:
-  * `DIGO_API_URL` – Provider endpoint (default `https://engage-api.digo.link/notify`).
-  * `DIGO_X_AUTHORIZATION` – Optional header for API auth.
-  * `DIGO_BEARER_TOKEN` – Optional bearer token.
+  * `DIGO_API_URL` – Provider endpoint (default `https://sfmc.comsensetechnologies.com/api/message`).
+  * `COMSENSE_BASIC_AUTH` – Base64 `username:password` credential applied to the `Authorization` header.
   * `DIGO_HTTP_TIMEOUT_MS` – Request timeout in milliseconds (default `15000`).
   * `DIGO_RETRY_ATTEMPTS` – Number of retries (default `3`).
   * `DIGO_RETRY_BACKOFF_MS` – Initial backoff (default `500` ms, exponential).

--- a/lib/digo-client.js
+++ b/lib/digo-client.js
@@ -14,9 +14,8 @@ class ProviderRequestError extends Error {
 
 function getConfig() {
   return {
-    url: process.env.DIGO_API_URL || 'https://engage-api.digo.link/notify',
-    xAuthorization: process.env.DIGO_X_AUTHORIZATION,
-    bearerToken: process.env.DIGO_BEARER_TOKEN,
+    url: process.env.DIGO_API_URL || 'https://sfmc.comsensetechnologies.com/api/message',
+    basicAuth: process.env.COMSENSE_BASIC_AUTH,
     timeout: Number(process.env.DIGO_HTTP_TIMEOUT_MS || 15000),
     retryAttempts: Number(process.env.DIGO_RETRY_ATTEMPTS || 3),
     retryBackoffMs: Number(process.env.DIGO_RETRY_BACKOFF_MS || 500),
@@ -28,11 +27,8 @@ function buildHeaders(config) {
   const headers = {
     'Content-Type': 'application/json'
   };
-  if (config.xAuthorization) {
-    headers['X-Authorization'] = config.xAuthorization;
-  }
-  if (config.bearerToken) {
-    headers.Authorization = `Bearer ${config.bearerToken}`;
+  if (config.basicAuth) {
+    headers.Authorization = `Basic ${config.basicAuth}`;
   }
   return headers;
 }


### PR DESCRIPTION
## Summary
- update the DIGO client configuration to use the Comsense endpoint and basic auth credential
- refresh documentation to describe the new COMSENSE_BASIC_AUTH environment variable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da2f8b68e48330819ab4d463857800