### PR TITLE
Update DIGO payload to new messaging schema

### DIFF
--- a/lib/activity-validation.js
+++ b/lib/activity-validation.js
@@ -74,8 +74,23 @@ function validateExecuteRequest(body) {
   const { value: telemarketerId, error: telemarketerError } = validateRequiredField('TELEMARKETER_ID', args.TELEMARKETER_ID);
   if (telemarketerError) errors.push(telemarketerError);
 
-  const { value: message, error: messageError } = validateRequiredField('message', args.message);
+  const messageSource = args.messageText !== undefined ? args.messageText : args.message;
+  const { value: message, error: messageError } = validateRequiredField('message', messageSource);
   if (messageError) errors.push(messageError);
+
+  const mappedValuesArg = args.mappedValues;
+  let mobilePhoneSource = args.mobilePhone;
+  if (
+    mappedValuesArg &&
+    typeof mappedValuesArg === 'object' &&
+    !Array.isArray(mappedValuesArg) &&
+    mappedValuesArg.mobilePhone !== undefined
+  ) {
+    mobilePhoneSource = mappedValuesArg.mobilePhone;
+  }
+
+  const { value: mobilePhone, error: mobilePhoneError } = validateRequiredField('mobilePhone', mobilePhoneSource);
+  if (mobilePhoneError) errors.push(mobilePhoneError);
 
   let transactionID = normalizeString(args.transactionID);
   if (!transactionID) {
@@ -86,6 +101,18 @@ function validateExecuteRequest(body) {
     throw new ValidationError('Invalid execute payload.', errors);
   }
 
+  const mappedValues = {};
+  if (mappedValuesArg && typeof mappedValuesArg === 'object' && !Array.isArray(mappedValuesArg)) {
+    Object.entries(mappedValuesArg).forEach(([key, value]) => {
+      const normalized = normalizeString(value);
+      if (normalized !== '') {
+        mappedValues[key] = normalized;
+      }
+    });
+  }
+
+  mappedValues.mobilePhone = mobilePhone;
+
   return {
     transactionID,
     campaignName,
@@ -94,6 +121,8 @@ function validateExecuteRequest(body) {
     TEMPLATE_ID: templateId,
     TELEMARKETER_ID: telemarketerId,
     message,
+    recipientMobilePhone: mobilePhone,
+    mappedValues,
     rawArguments: args
   };
 }

--- a/lib/digo-payload.js
+++ b/lib/digo-payload.js
@@ -2,52 +2,80 @@
 
 const { normalizeString, ValidationError } = require('./activity-validation');
 
-function resolveDataset(message, overrides) {
-  if (Array.isArray(overrides) && overrides.length > 0) {
-    return overrides
-      .map((item) => ({
-        msisdn: normalizeString(item.msisdn || item),
-        message: normalizeString(item.message || message)
-      }))
-      .filter((item) => item.msisdn !== '');
+function normalizeMappedValues(rawMappedValues) {
+  if (!rawMappedValues || typeof rawMappedValues !== 'object' || Array.isArray(rawMappedValues)) {
+    return {};
   }
 
-  const defaultList = (process.env.DIGO_DEFAULT_MSISDNS || '')
-    .split(',')
-    .map((entry) => normalizeString(entry))
-    .filter((entry) => entry !== '');
+  return Object.entries(rawMappedValues).reduce((acc, [key, value]) => {
+    const normalizedValue = normalizeString(value);
+    if (normalizedValue !== '') {
+      acc[key] = normalizedValue;
+    }
+    return acc;
+  }, {});
+}
 
-  if (defaultList.length === 0) {
-    throw new ValidationError('No recipients were provided for the SMS payload.', [
-      'Provide a dataSet array in the Journey Builder activity or configure DIGO_DEFAULT_MSISDNS.'
+function buildDigoPayload(args) {
+  const {
+    transactionID,
+    campaignName,
+    tiny,
+    PE_ID,
+    TEMPLATE_ID,
+    TELEMARKETER_ID,
+    message,
+    mappedValues = {},
+    recipientMobilePhone
+  } = args;
+
+  const normalizedMessage = normalizeString(message);
+  const sanitizedMappedValues = normalizeMappedValues(mappedValues);
+  const mobilePhone = normalizeString(
+    sanitizedMappedValues.mobilePhone || recipientMobilePhone || ''
+  );
+
+  if (mobilePhone === '') {
+    throw new ValidationError('No recipient mobilePhone provided for the DIGO payload.', [
+      'Map a mobilePhone value from the Journey data extension.'
     ]);
   }
 
-  return defaultList.map((msisdn) => ({ msisdn, message }));
-}
+  sanitizedMappedValues.mobilePhone = mobilePhone;
 
-function buildDigoPayload(args, options = {}) {
-  const { message, transactionID, campaignName, tiny, PE_ID, TEMPLATE_ID, TELEMARKETER_ID } = args;
-  const { dataSetOverride } = options;
-
-  const dataset = resolveDataset(message, dataSetOverride || args.dataSet);
-
-  return {
+  const payload = {
     transactionID,
-    campaignName,
-    oa: process.env.DIGO_ORIGINATOR || 'TACMPN',
-    channel: 'sms',
-    tiny,
-    tlv: {
-      PE_ID,
-      TEMPLATE_ID,
-      TELEMARKETER_ID
+    message: {
+      channel: 'sms',
+      content: {
+        type: 'text',
+        text: normalizedMessage
+      },
+      recipient: {
+        type: 'msisdn',
+        address: mobilePhone
+      }
     },
-    dataSet: dataset
+    sender: {
+      originator: normalizeString(process.env.DIGO_ORIGINATOR || 'TACMPN')
+    },
+    preferences: {
+      tiny
+    },
+    metaData: {
+      campaignName,
+      tlv: {
+        PE_ID,
+        TEMPLATE_ID,
+        TELEMARKETER_ID
+      },
+      mappedValues: sanitizedMappedValues
+    }
   };
+
+  return payload;
 }
 
 module.exports = {
-  buildDigoPayload,
-  resolveDataset
+  buildDigoPayload
 };


### PR DESCRIPTION
## Summary
- refactor the DIGO payload builder to emit the new message/sender/preferences/metaData structure and include mapped DE values
- extend execute request validation to surface message/mobilePhone inputs and pass mapped values to the server
- update the execute handler logging to reflect the new payload shape while masking sensitive fields

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68da2f8d8f608330a32eae6f7094667b