### PR TITLE
Add attribute mapping fields for SMS activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ npm start
 
 The server listens on `http://localhost:3001` by default. For Journey Builder integration, expose the port via a tunneling tool such as `ngrok` and configure your Custom Activity package to use the tunnel URL.
 
+### Journey Data Binding Tokens
+
+Use the inspector's attribute picker to map Data Extension values into the activity. The **First Name Attribute** and **Mobile Phone Attribute** fields expect tokens in the `{{Contact.Attribute.<DataExtensionName>.<FieldName>}}` format (for example, `{{Contact.Attribute.SMSAudience.FirstName}}` and `{{Contact.Attribute.SMSAudience.MobilePhone}}`). Journey Builder resolves the tokens at execution time, so do not wrap them in quotes or add additional braces.
+
 ### Testing and Tooling
 
 * `npm test` – Placeholder script (update when automated tests are added).

--- a/config-json.js
+++ b/config-json.js
@@ -126,6 +126,18 @@ module.exports = function configJSON(req) {
                 isNullable: 'False',
                 direction: 'in',
                 access: 'visible'
+              },
+              firstNameAttribute: {
+                dataType: 'Text',
+                isNullable: 'True',
+                direction: 'in',
+                access: 'visible'
+              },
+              mobilePhoneAttribute: {
+                dataType: 'Text',
+                isNullable: 'False',
+                direction: 'in',
+                access: 'visible'
               }
             }
           ],

--- a/docs/files/index.html.md
+++ b/docs/files/index.html.md
@@ -6,7 +6,7 @@ Provides the user interface for configuring the Custom Activity inside the Journ
 ## Structure Overview
 
 * Includes Salesforce Lightning Design System (SLDS) stylesheets and Google Fonts.
-* Defines form inputs for all execute-time fields: `transactionID`, `campaignName`, `tiny`, `PE_ID`, `TEMPLATE_ID`, `TELEMARKETER_ID`, `message`.
+* Defines form inputs for all execute-time fields: `transactionID`, `campaignName`, `tiny`, `PE_ID`, `TEMPLATE_ID`, `TELEMARKETER_ID`, `message`, `firstNameAttribute`, `mobilePhoneAttribute`.
 * Embeds inline `<script>` to auto-generate transaction IDs, manage error banner state, and expose helper functions for tests.
 * Loads the compiled `main.js` bundle at the end to wire Postmonger interactions.
 
@@ -17,6 +17,7 @@ Provides the user interface for configuring the Custom Activity inside the Journ
 | `.hero-banner` image | Visual banner at top of inspector for branding. |
 | `.activity-wrapper` | Container card that holds the activity form using custom theming variables. |
 | Form fields | Styled inputs/selects aligned with SLDS conventions. Required fields display helper text or error styling. |
+| Attribute helper text | Reminds users to use the Journey Builder attribute picker to insert `{{Contact.Attribute.<DataExtensionName>.<FieldName>}}` tokens for the `firstNameAttribute` and `mobilePhoneAttribute` inputs. |
 | Error banner (`#form-error-banner`) | Hidden by default; shown when client-side validation fails in the inline script. |
 | Inline IIFE | Defines `ensureTransactionId`, `hideError`, `showError`, binds blur/input listeners, and exposes `window.__activityForm`. |
 | `<script src="main.js">` | Loads the bundled JavaScript generated from `src/index.js`. |

--- a/index.html
+++ b/index.html
@@ -181,6 +181,22 @@
                     <input class="slds-form-element__control" id="message" type="text" name="message" value="">
                 </div>
 
+                <div class="form-field">
+                    <div><label for="firstNameAttribute">First Name Attribute:</label></div>
+                    <input class="slds-form-element__control" id="firstNameAttribute" type="text"
+                        name="firstNameAttribute" placeholder="{{Contact.Attribute.MyDE.FirstName}}">
+                    <span class="helper-text">Use the attribute picker to insert the Data Extension token for your contact's
+                        first name.</span>
+                </div>
+
+                <div class="form-field">
+                    <div><label for="mobilePhoneAttribute">Mobile Phone Attribute:</label></div>
+                    <input class="slds-form-element__control" id="mobilePhoneAttribute" type="text"
+                        name="mobilePhoneAttribute" placeholder="{{Contact.Attribute.MyDE.MobilePhone}}">
+                    <span class="helper-text">Use the attribute picker to insert the Data Extension token for the recipient's
+                        mobile number.</span>
+                </div>
+
                 <div id="form-error-banner" class="slds-notify slds-notify_alert slds-theme_alert-texture"
                     style="display:none; margin-top:1rem;" role="alert">
                     <span class="slds-assistive-text">Error</span>

--- a/main.js
+++ b/main.js
@@ -447,28 +447,44 @@
 				inArguments = []
 			}
 
-			/* let urlStringObj = inArguments.find((obj) => obj.urlString)
-			 let payloadStringObj = inArguments.find((obj) => obj.payload)
-		   
-			 if (urlStringObj) {
-			   prePopulateInput('url', urlStringObj.urlString)
-			 }
-		   
-			 if (payloadStringObj) {
-			   prePopulateInput('payload', JSON.stringify(payloadStringObj.payload, null, 4))
-			 }*/
+                        const [firstInArgument = {}] = inArguments
+                        const fieldsToPopulate = [
+                                'transactionID',
+                                'campaignName',
+                                'tiny',
+                                'PE_ID',
+                                'TEMPLATE_ID',
+                                'TELEMARKETER_ID',
+                                'message',
+                                'firstNameAttribute',
+                                'mobilePhoneAttribute'
+                        ]
 
-		}
+                        fieldsToPopulate.forEach((field) => {
+                                if (firstInArgument[field] !== undefined) {
+                                        prePopulateInput(field, firstInArgument[field])
+                                }
+                        })
+
+                }
 
 		// function jsFriendlyJSONStringify (s) {
 		//   return JSON.stringify(s).replace('\\', '')
 		// }
 
 
-		function prePopulateInput(inputFieldId, inputValue) {
-			let inputField = document.getElementById(inputFieldId)
-			inputField.value = inputValue
-		}
+                function prePopulateInput(inputFieldId, inputValue) {
+                        let inputField = document.getElementById(inputFieldId)
+                        if (!inputField) {
+                                return
+                        }
+
+                        if (inputValue === undefined || inputValue === null) {
+                                inputField.value = ''
+                        } else {
+                                inputField.value = inputValue
+                        }
+                }
 
 		function onDoneButtonClick() {
 			// we must set metaData.isConfigured in order to tell JB that this activity
@@ -479,12 +495,14 @@
 			let PE_ID = document.getElementById('PE_ID').value
 			let TEMPLATE_ID = document.getElementById('TEMPLATE_ID').value
 			let TELEMARKETER_ID = document.getElementById('TELEMARKETER_ID').value
-			let message = document.getElementById('message').value
+                        let message = document.getElementById('message').value
+                        let firstNameAttribute = document.getElementById('firstNameAttribute').value
+                        let mobilePhoneAttribute = document.getElementById('mobilePhoneAttribute').value
 
 
 			if (TEMPLATE_ID.length > 0) {
 				activity.metaData.isConfigured = true;
-				activity.arguments.execute.inArguments = [{ transactionID, campaignName, tiny, PE_ID, TEMPLATE_ID, TELEMARKETER_ID, message }]
+                                activity.arguments.execute.inArguments = [{ transactionID, campaignName, tiny, PE_ID, TEMPLATE_ID, TELEMARKETER_ID, message, firstNameAttribute, mobilePhoneAttribute }]
 
 				connection.trigger('updateActivity', activity)
 				console.log(`Activity has been updated. Activity: ${JSON.stringify(activity)}`)


### PR DESCRIPTION
## Summary
- add first name and mobile phone attribute inputs to the inspector UI with guidance on using the attribute picker
- persist the new attribute fields in Journey Builder inArguments and expose them through the config schema
- document the expected data extension token format in the README and docs

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da2f8edafc8330ba25504133b8ecaa