### PR TITLE
Update executeV2 request documentation

### DIFF
--- a/app.js
+++ b/app.js
@@ -116,18 +116,11 @@ app.post('/stop', function (req, res) {
 {
   inArguments: [
     {
-      urlString: 'https://sfmc.comsensetechnologies.com/',
-      payload: [Object]
+      message: 'Thank you for your purchase!',
+      firstNameAttribute: '{{Contact.Attribute.MyDE.FirstName}}',
+      mobilePhoneAttribute: '{{Contact.Attribute.MyDE.mobile}}'
     }
   ];
-  outArguments: [];
-  activityObjectID: '9841db2b-a598-4b3a-b1af-0dd71cd8939a';
-  journeyId: 'b544882d-4160-4114-a419-7ff43e776b47';
-  activityId: '9841db2b-a598-4b3a-b1af-0dd71cd8939a';
-  definitionInstanceId: '4f60d95d-663e-468d-896a-d85c73a46f4a';
-  activityInstanceId: '394345a0-38f5-4b1b-9223-a271e6046f7f';
-  keyValue: '00Q4S000002CsSdUAK_v2';
-  mode: 0
 }
 
 app.post('/executeV2', async (req, res) => {

--- a/docs/files/app.js.md
+++ b/docs/files/app.js.md
@@ -44,19 +44,17 @@ Primary Express server responsible for hosting the custom activity assets and ex
 ## Usage Example
 Trigger the execution endpoint manually during development:
 ```bash
-curl -X POST http://localhost:3001/executeV2 \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "inArguments": [{
-      "campaignName": "Sample",
-      "tiny": "1",
-      "PE_ID": "12345",
-      "TEMPLATE_ID": "67890",
-      "TELEMARKETER_ID": "TM-001",
-      "message": "Test SMS"
-    }],
-    "keyValue": "CONTACT-001"
-  }'
+curl --location 'http://localhost:3001/executeV2' \
+--header 'Content-Type: application/json' \
+--data '{
+  "inArguments": [
+    {
+      "message": "Thank you for your purchase!",
+      "firstNameAttribute": "{{Contact.Attribute.MyDE.FirstName}}",
+      "mobilePhoneAttribute": "{{Contact.Attribute.MyDE.mobile}}"
+    }
+  ]
+}'
 ```
 
 ## Related Files

--- a/docs/project-structure/app.js.md
+++ b/docs/project-structure/app.js.md
@@ -316,27 +316,20 @@ app.post('/stop', function(req, res) {
 ```
 
 ## Define the execution route
-The execution route is the endpoint the Journey calls when a Subscriber enters the activity. It is where the magic happens! ✨ Marketing Cloud sends a request with payload containing metadata of the event. We can access this payload via ```req.body``` property. The most important properties from this metadata are the ```req.body.inArguments``` and ```req.body.keyValue```. The ```inArguments``` contains any static value (example: a datetime stamp) or value defined during the configuration of the activity (example: populated in the activity UI). ```keyValue``` is Contact Key of the Subscriber entering the activity. 
+The execution route is the endpoint the Journey calls when a Subscriber enters the activity. It is where the magic happens! ✨ Marketing Cloud sends a request with payload containing metadata of the event. We can access this payload via ```req.body``` property. The most important portion of this metadata is ```req.body.inArguments```, which contains static values (example: a datetime stamp) or values defined during the configuration of the activity (example: populated in the activity UI).
 
-Below, is a sample of a payload request our custom activity receives from Marketing Cloud. Note that  ```inArguments.urlString``` and ```inArguments.payload``` 
+Below, is a sample of a payload request our custom activity receives from Marketing Cloud. Note how the payload delivers the SMS content alongside the bound attributes for first name and mobile number.
 
 ```javascript
 // REQ.BODY SAMPLE
 {
   inArguments: [
     {
-      urlString: 'www.sampleurlstring.com',
-      payload: [Object]
+      message: 'Thank you for your purchase!',
+      firstNameAttribute: '{{Contact.Attribute.MyDE.FirstName}}',
+      mobilePhoneAttribute: '{{Contact.Attribute.MyDE.mobile}}'
     }
-  ],
-  outArguments: [],
-  activityObjectID: '9841db2b-a598-4b3a-b1af-0dd71cd8939a',
-  journeyId: 'b544882d-4160-4114-a419-7ff43e776b47',
-  activityId: '9841db2b-a598-4b3a-b1af-0dd71cd8939a',
-  definitionInstanceId: '4f60d95d-663e-468d-896a-d85c73a46f4a',
-  activityInstanceId: '394345a0-38f5-4b1b-9223-a271e6046f7f',
-  keyValue: 'contactKeyValue',
-  mode: 0
+  ]
 }
 ```
 

--- a/postman/sfmc-custom-activity.postman_collection.json
+++ b/postman/sfmc-custom-activity.postman_collection.json
@@ -169,7 +169,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"inArguments\": [\n    {\n      \"campaignName\": \"Sample Campaign\",\n      \"tiny\": true,\n      \"PE_ID\": \"PE123\",\n      \"TEMPLATE_ID\": \"TMP456\",\n      \"TELEMARKETER_ID\": \"TEL789\",\n      \"message\": \"Thank you for your purchase!\"\n    }\n  ],\n  \"outArguments\": [],\n  \"activityObjectID\": \"00000000-0000-0000-0000-000000000000\",\n  \"journeyId\": \"11111111-1111-1111-1111-111111111111\",\n  \"activityId\": \"22222222-2222-2222-2222-222222222222\",\n  \"definitionInstanceId\": \"33333333-3333-3333-3333-333333333333\",\n  \"activityInstanceId\": \"44444444-4444-4444-4444-444444444444\",\n  \"keyValue\": \"CONTACT_KEY\",\n  \"mode\": 0\n}"
+              "raw": "{\n  \"inArguments\": [\n    {\n      \"message\": \"Thank you for your purchase!\",\n      \"firstNameAttribute\": \"{{Contact.Attribute.MyDE.FirstName}}\",\n      \"mobilePhoneAttribute\": \"{{Contact.Attribute.MyDE.mobile}}\"\n    }\n  ]\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/executeV2",


### PR DESCRIPTION
## Summary
- update executeV2 request examples to remove deprecated metadata fields
- refresh documentation and Postman collection to show message and attribute bindings

## Testing
- not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68da48e4151c8330be4a45ce6a917600