### PR TITLE
Update executeV2 request samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The server listens on `http://localhost:3001` by default. For Journey Builder in
 
 ### Journey Data Binding Tokens
 
-Use the inspector's attribute picker to map Data Extension values into the activity. The **First Name Attribute** and **Mobile Phone Attribute** fields expect tokens in the `{{Contact.Attribute.<DataExtensionName>.<FieldName>}}` format (for example, `{{Contact.Attribute.SMSAudience.FirstName}}` and `{{Contact.Attribute.SMSAudience.MobilePhone}}`). Journey Builder resolves the tokens at execution time, so do not wrap them in quotes or add additional braces.
+Use the inspector's attribute picker to map Data Extension values into the activity. The **First Name Attribute** and **Mobile Phone Attribute** fields expect tokens in the `{{Contact.Attribute.<DataExtensionName>.<FieldName>}}` format (for example, `{{Contact.Attribute.SMSAudience.FirstName}}` and `{{Contact.Attribute.SMSAudience.mobile}}`). Journey Builder resolves the tokens at execution time, so do not wrap them in quotes or add additional braces.
 
 ### Testing and Tooling
 

--- a/docs/files/app.js.md
+++ b/docs/files/app.js.md
@@ -54,9 +54,8 @@ X-Correlation-Id: 12345
   "inArguments": [
     {
       "message": "Welcome!",
-      "mobilePhone": "+12025550123",
       "firstNameAttribute": "{{Contact.Attribute.MyDE.FirstName}}",
-      "mobilePhoneAttribute": "{{Contact.Attribute.MyDE.MobilePhone}}"
+      "mobilePhoneAttribute": "{{Contact.Attribute.MyDE.mobile}}"
     }
   ]
 }

--- a/postman/sfmc-custom-activity.postman_collection.json
+++ b/postman/sfmc-custom-activity.postman_collection.json
@@ -169,7 +169,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"inArguments\": [\n    {\n      \"message\": \"Thank you for your purchase!\",\n      \"mobilePhone\": \"+12025550123\",\n      \"firstNameAttribute\": \"{{Contact.Attribute.MyDE.FirstName}}\",\n      \"mobilePhoneAttribute\": \"{{Contact.Attribute.MyDE.MobilePhone}}\"\n    }\n  ],\n  \"outArguments\": [],\n  \"activityObjectID\": \"00000000-0000-0000-0000-000000000000\",\n  \"journeyId\": \"11111111-1111-1111-1111-111111111111\",\n  \"activityId\": \"22222222-2222-2222-2222-222222222222\",\n  \"definitionInstanceId\": \"33333333-3333-3333-3333-333333333333\",\n  \"activityInstanceId\": \"44444444-4444-4444-4444-444444444444\",\n  \"keyValue\": \"CONTACT_KEY\",\n  \"mode\": 0\n}"
+              "raw": "{\n  \"inArguments\": [\n    {\n      \"message\": \"Thank you for your purchase!\",\n      \"firstNameAttribute\": \"{{Contact.Attribute.MyDE.FirstName}}\",\n      \"mobilePhoneAttribute\": \"{{Contact.Attribute.MyDE.mobile}}\"\n    }\n  ]\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/executeV2",


### PR DESCRIPTION
## Summary
- simplify the sample executeV2 payload by removing unused fields and aligning the mobile phone binding
- update the README and docs usage examples to reference the corrected attribute token

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da4cddf89c83308b2439a2cb0fc62a