### PR TITLE
Add detailed logging for activity lifecycle and provider interactions

### DIFF
--- a/lib/activity-validation.js
+++ b/lib/activity-validation.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const logger = require('./logger');
+
 class ValidationError extends Error {
   constructor(message, details = []) {
     super(message);
@@ -43,6 +45,7 @@ function validateRequiredField(fieldName, value) {
 }
 
 function validateExecuteRequest(body) {
+  logger.debug('Validating execute request body.', { body });
   const args = parseInArguments(body);
   const errors = [];
 
@@ -65,6 +68,7 @@ function validateExecuteRequest(body) {
   if (mobilePhoneError) errors.push(mobilePhoneError);
 
   if (errors.length > 0) {
+    logger.warn('Execute request validation failed.', { errors });
     throw new ValidationError('Invalid execute payload.', errors);
   }
 
@@ -87,6 +91,8 @@ function validateExecuteRequest(body) {
     rawArguments: args
   };
 }
+
+logger.debug('Execute request validation module initialized.');
 
 module.exports = {
   ValidationError,

--- a/lib/digo-client.js
+++ b/lib/digo-client.js
@@ -43,9 +43,25 @@ async function sendPayloadWithRetry(payload, options = {}) {
   const backoffMs = options.retryBackoffMs || config.retryBackoffMs;
   const client = options.httpClient || axios;
   const headers = { ...buildHeaders(config), ...(options.headers || {}) };
+  const correlationId = options.correlationId;
+
+  logger.debug('Preparing provider request.', {
+    correlationId,
+    config: {
+      url: config.url,
+      timeout: config.timeout,
+      retryAttempts: attempts,
+      retryBackoffMs: backoffMs,
+      stubResponses: config.stubResponses
+    },
+    payload
+  });
 
   if (config.stubResponses) {
-    logger.info('DIGO_STUB_MODE enabled, skipping outbound request.', { payloadSize: JSON.stringify(payload).length });
+    logger.info('DIGO_STUB_MODE enabled, skipping outbound request.', {
+      correlationId,
+      payloadSize: JSON.stringify(payload).length
+    });
     return {
       status: 200,
       data: {
@@ -62,14 +78,24 @@ async function sendPayloadWithRetry(payload, options = {}) {
   while (attempt < attempts) {
     attempt += 1;
     try {
-      logger.info('Sending payload to DIGO provider.', { attempt, attempts });
+      logger.info('Sending payload to DIGO provider.', {
+        correlationId,
+        attempt,
+        attempts,
+        url: config.url
+      });
       const response = await client.post(config.url, payload, {
         headers,
         timeout: config.timeout
       });
 
       if (response.status >= 200 && response.status < 300) {
-        logger.info('Provider call succeeded.', { status: response.status });
+        logger.info('Provider call succeeded.', {
+          correlationId,
+          attempt,
+          status: response.status,
+          responseBody: response.data
+        });
         return response;
       }
 
@@ -85,12 +111,21 @@ async function sendPayloadWithRetry(payload, options = {}) {
         responseBody: error.response ? error.response.data : undefined
       };
       lastError = new ProviderRequestError('Failed to send payload to provider.', status, details);
-      logger.warn('Provider call failed.', { attempt, attempts, details });
+      logger.warn('Provider call failed.', {
+        correlationId,
+        attempt,
+        attempts,
+        details
+      });
       if (!shouldRetry || attempt >= attempts) {
         break;
       }
       const waitMs = backoffMs * Math.pow(2, attempt - 1);
-      logger.info('Retrying provider call after backoff.', { waitMs });
+      logger.info('Retrying provider call after backoff.', {
+        correlationId,
+        attempt,
+        waitMs
+      });
       await delay(waitMs);
     }
   }

--- a/lib/digo-payload.js
+++ b/lib/digo-payload.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const logger = require('./logger');
 const { normalizeString, ValidationError } = require('./activity-validation');
 
 function normalizeMappedValues(rawMappedValues) {
@@ -22,6 +23,12 @@ function buildDigoPayload(args) {
     mappedValues = {},
     recipientMobilePhone
   } = args;
+
+  logger.debug('Building DIGO payload.', {
+    message,
+    mappedValues,
+    recipientMobilePhone
+  });
 
   const normalizedMessage = normalizeString(message);
   const sanitizedMappedValues = normalizeMappedValues(mappedValues);
@@ -56,6 +63,10 @@ function buildDigoPayload(args) {
       mappedValues: sanitizedMappedValues
     }
   };
+
+  logger.debug('DIGO payload built successfully.', {
+    payload
+  });
 
   return payload;
 }


### PR DESCRIPTION
## Summary
- add granular logging for lifecycle hooks and execute requests, including received payloads and validation outcomes
- trace resolved contact values and provider payload construction before invoking the DIGO API
- expand provider client logging to capture retry behavior, request metadata, and responses

## Testing
- npm test *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_68da675caa208330bd1dc443ba21b3b8