### PR TITLE
Fix publish hook base URL resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Automated tests are not defined. Validate functionality manually by triggering t
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `PORT` | `3001` | Express server listening port. |
-| `SFMC_BASE_URL` | _not set_ | Optionally override the hostname used in `config-json.js` if hosting endpoints under a different domain. Update the file accordingly when customizing. |
+| `SFMC_BASE_URL` | _not set_ | Override the base URL used in `config-json.js`. When unset, the service derives the base URL from the incoming request (including `X-Forwarded-*` headers) and falls back to `https://sfmc.comsensetechnologies.com`. |
 | `LOG_LEVEL` | _not set_ | Implement custom logging controls in `app.js` if required (currently a simple console logger is used). |
 
 > **Security note:** `/executeV2` forwards SMS payloads to an external API using static credentials. Store these secrets in environment variables or a secure vault before deploying to production.

--- a/config-json.js
+++ b/config-json.js
@@ -9,7 +9,37 @@
 // ****************
 
 
+const DEFAULT_BASE_URL = 'https://sfmc.comsensetechnologies.com';
+
+function resolveBaseUrl(req) {
+  if (process.env.SFMC_BASE_URL) {
+    return process.env.SFMC_BASE_URL.replace(/\/$/, '');
+  }
+
+  if (!req) {
+    return DEFAULT_BASE_URL;
+  }
+
+  const forwardedHost = req.get('x-forwarded-host');
+  const host = (forwardedHost || req.get('host') || '').split(',')[0]?.trim();
+
+  if (!host) {
+    return DEFAULT_BASE_URL;
+  }
+
+  const forwardedProto = req.get('x-forwarded-proto');
+  const proto = (forwardedProto || req.protocol || 'https').split(',')[0]?.trim();
+
+  if (!proto) {
+    return DEFAULT_BASE_URL;
+  }
+
+  return `${proto}://${host}`.replace(/\/$/, '');
+}
+
 module.exports = function configJSON(req) {
+  const baseUrl = resolveBaseUrl(req);
+
   return {
     workflowApiVersion: '1.1',
     // metaData points 
@@ -44,22 +74,22 @@ module.exports = function configJSON(req) {
         concurrentRequests: 5,
         // url:'https://customactivityv2.herokuapp.com/execute',
         // url:'http://localhost:3001/executeV2',
-        url: 'https://sfmc.comsensetechnologies.com/executeV2',
+        url: `${baseUrl}/executeV2`,
       },
     },
 
     configurationArguments: {
       save: {
-        url: 'https://sfmc.comsensetechnologies.com/save'
+        url: `${baseUrl}/save`
       },
       publish: {
-        url: 'https://sfmc.comsensetechnologies.com/publish'
+        url: `${baseUrl}/publish`
       },
       validate: {
-        url: 'https://sfmc.comsensetechnologies.com/validate'
+        url: `${baseUrl}/validate`
       },
       stop: {
-        url: 'https://sfmc.comsensetechnologies.com/stop'
+        url: `${baseUrl}/stop`
       }
     },
 


### PR DESCRIPTION
## Summary
- derive lifecycle and execution endpoint URLs from the inbound request (or SFMC_BASE_URL) so they always target the currently deployed host
- document the new base URL behaviour in the environment configuration table

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da73b7edf083309af647639a75a3ea