### PR TITLE
Fix lifecycle validation to unblock publish hook

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,7 +14,11 @@ const path = require('path');
 const configJSON = require('./config-json');
 const { v4: uuidv4 } = require('uuid');
 const logger = require('./lib/logger');
-const { ValidationError, validateExecuteRequest } = require('./lib/activity-validation');
+const {
+  ValidationError,
+  validateExecuteRequest,
+  validateLifecycleRequest
+} = require('./lib/activity-validation');
 const { buildDigoPayload } = require('./lib/digo-payload');
 const { sendPayloadWithRetry, ProviderRequestError } = require('./lib/digo-client');
 
@@ -73,7 +77,7 @@ function acknowledgeLifecycleEvent(routeName) {
     });
     try {
       if (req.body && Array.isArray(req.body.inArguments) && req.body.inArguments.length > 0) {
-        validateExecuteRequest(req.body);
+        validateLifecycleRequest(req.body);
         logger.debug(`${routeName} lifecycle payload validated successfully.`, {
           correlationId: req.correlationId
         });

--- a/docs/files/lib/activity-validation.js.md
+++ b/docs/files/lib/activity-validation.js.md
@@ -1,7 +1,7 @@
 # `lib/activity-validation.js`
 
 ## Role in the System
-Centralizes validation logic for Journey Builder execute payloads. Ensures required fields are present, normalizes user input, and raises consistent errors for API handlers.
+Centralizes validation logic for Journey Builder lifecycle and execute payloads. Ensures required fields are present, normalizes user input, and raises consistent errors for API handlers.
 
 ## Public API
 
@@ -9,6 +9,7 @@ Centralizes validation logic for Journey Builder execute payloads. Ensures requi
 | --- | --- |
 | `ValidationError` | Custom `Error` subclass used to signal invalid requests with details and HTTP 400 status codes. |
 | `validateExecuteRequest(body)` | Validates the structure and content of a Journey Builder execute payload and returns normalized arguments. |
+| `validateLifecycleRequest(body)` | Validates lifecycle payloads (save/publish/validate/stop) to ensure required configuration fields are present. |
 | `normalizeString(value)` | Utility that coerces values to trimmed strings, returning an empty string for `null`/`undefined`. |
 
 ## Key Parameters and Return Types
@@ -16,6 +17,9 @@ Centralizes validation logic for Journey Builder execute payloads. Ensures requi
 * `validateExecuteRequest(body)` expects a Marketing Cloud execute payload object containing `inArguments`.
   * Returns an object `{ message, recipientMobilePhone, mappedValues, rawArguments }`.
   * Throws `ValidationError` with `details` array describing missing or invalid fields.
+* `validateLifecycleRequest(body)` expects lifecycle payloads containing configuration arguments.
+  * Returns `{ message, mobilePhoneAttribute, rawArguments }` when the payload is complete.
+  * Throws `ValidationError` with descriptive error details when required configuration fields are missing.
 * `normalizeString(value)` accepts any value and returns a trimmed string.
 
 ## External Dependencies
@@ -25,24 +29,35 @@ Centralizes validation logic for Journey Builder execute payloads. Ensures requi
 ## Data Flow
 
 1. `validateExecuteRequest` delegates to `parseInArguments` (internal) to ensure the payload contains an object inside `inArguments`.
-2. Required fields (`message`, `mobilePhone`) are normalized and validated using helper functions.
-3. Aggregates validation errors and throws once so that API handlers can emit a single structured response.
-4. On success, the returned object contains normalized values alongside the raw input object for downstream use.
+2. Lifecycle requests validate `message` and `mobilePhoneAttribute`, ensuring configuration completeness.
+3. Execute requests validate runtime `message` and `mobilePhone` values, normalize mapped attributes, and surface descriptive errors.
+4. Aggregates validation errors and throws once so that API handlers can emit a single structured response.
+5. On success, the returned object contains normalized values alongside the raw input object for downstream use.
 
 ## Error Handling and Edge Cases
 
 * Missing or non-array `inArguments` raise `ValidationError` with clear messaging.
-* Missing or blank `mobilePhone` values surface descriptive errors to encourage proper Journey attribute mapping.
+* Missing or blank `mobilePhoneAttribute` values surface descriptive errors during lifecycle validation so Journey Builder blocks publishing misconfigured activities.
+* Missing or blank `mobilePhone` values surface descriptive errors to encourage proper Journey attribute mapping at execute time.
 * Trailing/leading spaces are trimmed to avoid mismatches with provider requirements.
 
 ## Usage Example
 
 ```js
-const { validateExecuteRequest } = require('./lib/activity-validation');
+const { validateExecuteRequest, validateLifecycleRequest } = require('./lib/activity-validation');
 
 try {
   const args = validateExecuteRequest(req.body);
   // proceed with building provider payload
+} catch (error) {
+  if (error instanceof ValidationError) {
+    res.status(error.statusCode).json({ status: 'invalid', details: error.details });
+  }
+}
+
+try {
+  validateLifecycleRequest(req.body);
+  // acknowledge lifecycle call
 } catch (error) {
   if (error instanceof ValidationError) {
     res.status(error.statusCode).json({ status: 'invalid', details: error.details });

--- a/lib/activity-validation.js
+++ b/lib/activity-validation.js
@@ -92,10 +92,38 @@ function validateExecuteRequest(body) {
   };
 }
 
+function validateLifecycleRequest(body) {
+  logger.debug('Validating lifecycle request body.', { body });
+  const args = parseInArguments(body);
+  const errors = [];
+
+  const messageSource = args.messageText !== undefined ? args.messageText : args.message;
+  const { value: message, error: messageError } = validateRequiredField('message', messageSource);
+  if (messageError) errors.push(messageError);
+
+  const { value: mobilePhoneAttribute, error: mobilePhoneAttributeError } = validateRequiredField(
+    'mobilePhoneAttribute',
+    args.mobilePhoneAttribute
+  );
+  if (mobilePhoneAttributeError) errors.push(mobilePhoneAttributeError);
+
+  if (errors.length > 0) {
+    logger.warn('Lifecycle request validation failed.', { errors });
+    throw new ValidationError('Invalid lifecycle payload.', errors);
+  }
+
+  return {
+    message,
+    mobilePhoneAttribute,
+    rawArguments: args
+  };
+}
+
 logger.debug('Execute request validation module initialized.');
 
 module.exports = {
   ValidationError,
   validateExecuteRequest,
+  validateLifecycleRequest,
   normalizeString
 };


### PR DESCRIPTION
## Summary
- add a lifecycle-specific payload validator so save/publish/validate/stop requests only check for required configuration fields
- update the custom activity documentation to describe the new lifecycle validator API

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68da7739a3b08330b0fd15e3e825af12