### PR TITLE
Add structured logging for lifecycle and execute flows

### DIFF
--- a/lib/digo-client.js
+++ b/lib/digo-client.js
@@ -2,6 +2,7 @@
 
 const axios = require('axios');
 const logger = require('./logger');
+const { sanitizeObject, sanitizeHeaders } = require('./log-sanitizer');
 
 class ProviderRequestError extends Error {
   constructor(message, statusCode, details) {
@@ -45,6 +46,9 @@ async function sendPayloadWithRetry(payload, options = {}) {
   const headers = { ...buildHeaders(config), ...(options.headers || {}) };
   const correlationId = options.correlationId;
 
+  const sanitizedPayload = sanitizeObject(payload);
+  const sanitizedHeaders = sanitizeHeaders(headers);
+
   logger.debug('Preparing provider request.', {
     correlationId,
     config: {
@@ -54,20 +58,22 @@ async function sendPayloadWithRetry(payload, options = {}) {
       retryBackoffMs: backoffMs,
       stubResponses: config.stubResponses
     },
-    payload
+    headers: sanitizedHeaders,
+    payload: sanitizedPayload
   });
 
   if (config.stubResponses) {
     logger.info('DIGO_STUB_MODE enabled, skipping outbound request.', {
       correlationId,
-      payloadSize: JSON.stringify(payload).length
+      payloadSize: JSON.stringify(payload).length,
+      payload: sanitizedPayload
     });
     return {
       status: 200,
       data: {
         stubbed: true,
         message: 'Stub mode enabled - payload not sent.',
-        echoedPayload: payload
+        echoedPayload: sanitizedPayload
       }
     };
   }
@@ -78,11 +84,14 @@ async function sendPayloadWithRetry(payload, options = {}) {
   while (attempt < attempts) {
     attempt += 1;
     try {
-      logger.info('Sending payload to DIGO provider.', {
+      logger.info('provider.request', {
         correlationId,
         attempt,
         attempts,
-        url: config.url
+        url: config.url,
+        method: 'POST',
+        headers: sanitizedHeaders,
+        payload: sanitizedPayload
       });
       const response = await client.post(config.url, payload, {
         headers,
@@ -90,28 +99,31 @@ async function sendPayloadWithRetry(payload, options = {}) {
       });
 
       if (response.status >= 200 && response.status < 300) {
-        logger.info('Provider call succeeded.', {
+        const sanitizedResponseBody = sanitizeObject(response.data);
+        logger.info('provider.response', {
           correlationId,
           attempt,
           status: response.status,
-          responseBody: response.data
+          body: sanitizedResponseBody
         });
         return response;
       }
 
+      const sanitizedUnexpectedBody = sanitizeObject(response.data);
       lastError = new ProviderRequestError('Unexpected provider response status.', response.status, {
-        responseBody: response.data
+        responseBody: sanitizedUnexpectedBody
       });
     } catch (error) {
       const status = error.response ? error.response.status : undefined;
       const shouldRetry = !status || status >= 500;
+      const sanitizedErrorBody = error.response ? sanitizeObject(error.response.data) : undefined;
       const details = {
         status,
         message: error.message,
-        responseBody: error.response ? error.response.data : undefined
+        responseBody: sanitizedErrorBody
       };
       lastError = new ProviderRequestError('Failed to send payload to provider.', status, details);
-      logger.warn('Provider call failed.', {
+      logger.warn('provider.error', {
         correlationId,
         attempt,
         attempts,

--- a/lib/log-sanitizer.js
+++ b/lib/log-sanitizer.js
@@ -1,0 +1,116 @@
+'use strict';
+
+function maskPhone(value) {
+  if (value === null || value === undefined) {
+    return value;
+  }
+  const stringValue = String(value);
+  const digits = stringValue.replace(/[^0-9+]/g, '');
+  if (digits.length <= 4) {
+    return '[REDACTED]';
+  }
+  const visiblePrefixLength = Math.min(3, stringValue.length);
+  const visibleSuffixLength = Math.min(2, Math.max(stringValue.length - visiblePrefixLength, 0));
+  const prefix = stringValue.slice(0, visiblePrefixLength);
+  const suffix = visibleSuffixLength > 0 ? stringValue.slice(-visibleSuffixLength) : '';
+  return `${prefix}***${suffix}`;
+}
+
+function maskName(value) {
+  if (value === null || value === undefined) {
+    return value;
+  }
+  const stringValue = String(value);
+  if (stringValue.length === 0) {
+    return stringValue;
+  }
+  if (stringValue.length === 1) {
+    return `${stringValue}***`;
+  }
+  return `${stringValue[0]}***${stringValue[stringValue.length - 1]}`;
+}
+
+function truncateMessage(value) {
+  if (value === null || value === undefined) {
+    return value;
+  }
+  const stringValue = String(value);
+  const MAX_LENGTH = 512;
+  if (stringValue.length <= MAX_LENGTH) {
+    return stringValue;
+  }
+  return `${stringValue.slice(0, MAX_LENGTH)}...`;
+}
+
+function sanitizeValue(key, value) {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item, index) => sanitizeValue(String(index), item));
+  }
+
+  if (typeof value === 'object') {
+    return sanitizeObject(value);
+  }
+
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  const lowerKey = key ? String(key).toLowerCase() : '';
+
+  if (
+    lowerKey.includes('auth') ||
+    lowerKey.includes('token') ||
+    lowerKey.includes('secret') ||
+    lowerKey.includes('password') ||
+    lowerKey.includes('key')
+  ) {
+    return '[REDACTED]';
+  }
+
+  if (lowerKey.includes('phone') || lowerKey.includes('mobile') || lowerKey.includes('recipient')) {
+    return maskPhone(value);
+  }
+
+  if (lowerKey.includes('name')) {
+    return maskName(value);
+  }
+
+  if (lowerKey.includes('message')) {
+    return truncateMessage(value);
+  }
+
+  return value;
+}
+
+function sanitizeObject(obj) {
+  if (obj === null || obj === undefined) {
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map((item, index) => sanitizeValue(String(index), item));
+  }
+
+  if (typeof obj !== 'object') {
+    return obj;
+  }
+
+  return Object.keys(obj).reduce((acc, key) => {
+    acc[key] = sanitizeValue(key, obj[key]);
+    return acc;
+  }, {});
+}
+
+function sanitizeHeaders(headers = {}) {
+  return sanitizeObject(headers);
+}
+
+module.exports = {
+  sanitizeValue,
+  sanitizeObject,
+  sanitizeHeaders
+};


### PR DESCRIPTION
## Summary
- add shared sanitization utilities for logging request and payload data safely
- enhance lifecycle hook logging to persist inArguments and capture validation state
- expand executeV2 and provider logging to trace extracted values, validation, and provider interactions

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68da7ddabff48330a3122a159ab6531d