### PR TITLE
Fix lifecycle inArguments persistence and validation

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,12 +14,7 @@ const path = require('path');
 const configJSON = require('./config-json');
 const { v4: uuidv4 } = require('uuid');
 const logger = require('./lib/logger');
-const {
-  ValidationError,
-  validateExecuteRequest,
-  validateLifecycleRequest,
-  normalizeString
-} = require('./lib/activity-validation');
+const { ValidationError, validateExecuteRequest, normalizeString } = require('./lib/activity-validation');
 const { buildDigoPayload } = require('./lib/digo-payload');
 const { sendPayloadWithRetry, ProviderRequestError } = require('./lib/digo-client');
 const { sanitizeObject, sanitizeValue } = require('./lib/log-sanitizer');
@@ -39,6 +34,8 @@ app.use(express.static(path.join(__dirname, 'dist')));
 app.use('/assets', express.static(designSystemAssetsPath));
 app.use('/images', express.static(path.join(__dirname, 'images')));
 
+const cache = new Map();
+
 // Attach a correlation id for every request so that logs are traceable.
 app.use((req, res, next) => {
   const correlationId = req.headers['x-correlation-id'] || uuidv4();
@@ -46,10 +43,6 @@ app.use((req, res, next) => {
   res.set('X-Correlation-Id', correlationId);
   next();
 });
-
-const lifecycleState = {
-  lastSavedInArguments: null
-};
 
 function getPrimaryInArguments(body) {
   if (!body || typeof body !== 'object') {
@@ -61,6 +54,25 @@ function getPrimaryInArguments(body) {
 
   if (firstInArguments && typeof firstInArguments === 'object' && !Array.isArray(firstInArguments)) {
     return firstInArguments;
+  }
+
+  return {};
+}
+
+function getLifecycleInArguments(body) {
+  if (!body || typeof body !== 'object') {
+    return {};
+  }
+
+  const lifecycleArgs =
+    body.arguments &&
+    body.arguments.execute &&
+    Array.isArray(body.arguments.execute.inArguments)
+      ? body.arguments.execute.inArguments[0]
+      : undefined;
+
+  if (lifecycleArgs && typeof lifecycleArgs === 'object' && !Array.isArray(lifecycleArgs)) {
+    return lifecycleArgs;
   }
 
   return {};
@@ -89,101 +101,101 @@ app.get('/config.json', function (req, res) {
   return res.status(200).json(configJSON(req));
 });
 
-function acknowledgeLifecycleEvent(routeName, options = {}) {
-  const { persistInArguments = false, statusOnInvoke } = options;
+app.post('/save', (req, res) => {
+  const correlationId = req.correlationId;
+  const inArguments = getLifecycleInArguments(req.body);
+  const lifecycleArray = Array.isArray(req.body?.arguments?.execute?.inArguments)
+    ? req.body.arguments.execute.inArguments
+    : [];
+  const inArgumentsPresent = lifecycleArray.length > 0;
+  const messageCandidate =
+    inArguments.messageText !== undefined ? inArguments.messageText : inArguments.message;
+  const normalizedMessage = normalizeString(messageCandidate);
+  const normalizedMobile = normalizeString(inArguments.mobilePhoneAttribute);
+  const missingFields = [];
+  if (normalizedMessage === '') missingFields.push('message');
+  if (normalizedMobile === '') missingFields.push('mobilePhoneAttribute');
 
-  return (req, res) => {
-    const correlationId = req.correlationId;
-    const primaryInArguments = getPrimaryInArguments(req.body);
-    const inArgumentsPresent = Object.keys(primaryInArguments).length > 0;
-    const sanitizedBody = sanitizeObject(req.body || {});
-    const sanitizedArguments = sanitizeObject(primaryInArguments);
-
-    logger.info(`${routeName} lifecycle hook invoked.`, {
-      correlationId,
-      status: statusOnInvoke || 'received',
-      inArgumentsPresent
-    });
-    logger.debug(`${routeName} lifecycle payload received.`, {
-      correlationId,
-      requestBody: sanitizedBody
-    });
-
-    if (persistInArguments && inArgumentsPresent) {
-      lifecycleState.lastSavedInArguments = primaryInArguments;
-      logger.info('save lifecycle inArguments persisted.', {
-        correlationId,
-        inArguments: sanitizedArguments
-      });
-    } else if (inArgumentsPresent) {
-      logger.debug(`${routeName} lifecycle inArguments snapshot.`, {
-        correlationId,
-        inArguments: sanitizedArguments
-      });
+  logger.info('save lifecycle hook invoked', {
+    correlationId,
+    status: 'received',
+    inArgumentsPresent,
+    fieldsPresent: {
+      message: normalizedMessage !== '',
+      mobilePhoneAttribute: normalizedMobile !== ''
     }
+  });
 
-    const messageCandidate =
-      primaryInArguments.messageText !== undefined
-        ? primaryInArguments.messageText
-        : primaryInArguments.message;
-    const messagePresent = normalizeString(messageCandidate) !== '';
-    const mobilePresent = normalizeString(primaryInArguments.mobilePhoneAttribute) !== '';
+  if (missingFields.length > 0) {
+    logger.warn('save validation snapshot', { correlationId, missingFields });
+    return res.status(400).json({ ok: false, missing: missingFields });
+  }
 
-    const missingFields = [];
-    if (!messagePresent) missingFields.push('message');
-    if (!mobilePresent) missingFields.push('mobilePhoneAttribute');
+  cache.set('activityConfig', inArguments);
+  logger.info('save lifecycle config persisted', {
+    correlationId,
+    snapshot: sanitizeObject(inArguments)
+  });
 
-    logger[missingFields.length > 0 ? 'warn' : 'info'](`${routeName} lifecycle validation snapshot.`, {
-      correlationId,
-      missingFields,
-      fieldsPresent: {
-        message: messagePresent,
-        mobilePhoneAttribute: mobilePresent
-      }
-    });
+  return res.json({ ok: true });
+});
 
-    try {
-      if (inArgumentsPresent) {
-        validateLifecycleRequest(req.body);
-        logger.debug(`${routeName} lifecycle payload validated successfully.`, {
-          correlationId
-        });
-      }
-    } catch (error) {
-      if (error instanceof ValidationError) {
-        logger.warn(`${routeName} validation failed.`, {
-          errors: error.details,
-          correlationId
-        });
-        return res.status(error.statusCode).json({
-          status: 'invalid',
-          message: error.message,
-          details: error.details
-        });
-      }
-      logger.error(`${routeName} unexpected error.`, {
-        message: error.message,
-        correlationId
-      });
-      return res.status(500).json({
-        status: 'error',
-        message: 'Unexpected error validating lifecycle request.'
-      });
+app.post('/validate', (req, res) => {
+  const correlationId = req.correlationId;
+  const inArguments = getLifecycleInArguments(req.body);
+  const lifecycleArray = Array.isArray(req.body?.arguments?.execute?.inArguments)
+    ? req.body.arguments.execute.inArguments
+    : [];
+  const inArgumentsPresent = lifecycleArray.length > 0;
+  const messageCandidate =
+    inArguments.messageText !== undefined ? inArguments.messageText : inArguments.message;
+  const normalizedMessage = normalizeString(messageCandidate);
+  const normalizedMobile = normalizeString(inArguments.mobilePhoneAttribute);
+  const missingFields = [];
+  if (normalizedMessage === '') missingFields.push('message');
+  if (normalizedMobile === '') missingFields.push('mobilePhoneAttribute');
+
+  logger.info('validate lifecycle hook invoked', {
+    correlationId,
+    status: 'received',
+    inArgumentsPresent,
+    fieldsPresent: {
+      message: normalizedMessage !== '',
+      mobilePhoneAttribute: normalizedMobile !== ''
     }
+  });
 
-    return res.status(200).json({ status: 'ok' });
-  };
-}
+  if (missingFields.length > 0) {
+    logger.warn('validate validation snapshot', { correlationId, missingFields });
+    return res.status(400).json({ ok: false, missing: missingFields });
+  }
 
-app.post('/save', acknowledgeLifecycleEvent('save', { persistInArguments: true }));
-app.post(
-  '/publish',
-  acknowledgeLifecycleEvent('publish', {
-    statusOnInvoke: 'ready'
-  })
-);
-app.post('/validate', acknowledgeLifecycleEvent('validate'));
-app.post('/stop', acknowledgeLifecycleEvent('stop'));
+  return res.json({ ok: true });
+});
+
+app.post('/publish', (req, res) => {
+  const correlationId = req.correlationId;
+  const cachedConfig = cache.get('activityConfig') || {};
+  const missingFields = ['message', 'mobilePhoneAttribute'].filter((field) => !cachedConfig[field]);
+
+  logger.info('publish lifecycle hook invoked', {
+    correlationId,
+    status: missingFields.length ? 'not_ready' : 'ready',
+    inArgumentsPresent: missingFields.length === 0
+  });
+
+  if (missingFields.length > 0) {
+    return res.status(400).json({ ok: false, missing: missingFields });
+  }
+
+  return res.json({ ok: true });
+});
+
+app.post('/stop', (req, res) => {
+  const correlationId = req.correlationId;
+  logger.info('stop lifecycle hook invoked', { correlationId, status: 'received' });
+  return res.json({ ok: true });
+});
 
 app.post('/executeV2', async (req, res) => {
   const correlationId = req.correlationId;
@@ -193,7 +205,7 @@ app.post('/executeV2', async (req, res) => {
   const sanitizedRequestBody = sanitizeObject(requestBody);
   const sanitizedPrimaryArgs = sanitizeObject(primaryInArguments);
 
-  logger.info('executeV2 received.', {
+  logger.info('executeV2 received', {
     correlationId,
     inArgumentsPresent: inArgumentsArray.length > 0
   });
@@ -205,6 +217,21 @@ app.post('/executeV2', async (req, res) => {
     correlationId,
     inArguments: sanitizedPrimaryArgs
   });
+  logger.debug('executeV2.extract', {
+    correlationId,
+    firstName: sanitizeValue('firstName', primaryInArguments.firstNameAttribute),
+    mobilePhone: sanitizeValue('mobilePhone', primaryInArguments.mobilePhoneAttribute),
+    messageExists: !!primaryInArguments.message
+  });
+
+  const lifecycleMissing = ['message', 'mobilePhoneAttribute'].filter(
+    (field) => !primaryInArguments[field]
+  );
+
+  if (lifecycleMissing.length > 0) {
+    logger.warn('executeV2.validate', { correlationId, missingFields: lifecycleMissing });
+    return res.status(400).json({ ok: false, missing: lifecycleMissing });
+  }
 
   const firstName =
     primaryInArguments.firstNameAttribute !== undefined
@@ -218,15 +245,6 @@ app.post('/executeV2', async (req, res) => {
     primaryInArguments.messageText !== undefined
       ? primaryInArguments.messageText
       : primaryInArguments.message;
-
-  logger.debug('executeV2.extract', {
-    correlationId,
-    extracted: {
-      firstName: sanitizeValue('firstName', firstName),
-      mobilePhone: sanitizeValue('mobilePhone', mobileAttribute),
-      message: sanitizeValue('message', messageValue)
-    }
-  });
 
   const mappedValuesMobile =
     primaryInArguments &&
@@ -244,14 +262,14 @@ app.post('/executeV2', async (req, res) => {
 
   const missingFields = [];
   if (normalizedMessage === '') missingFields.push('message');
-  if (normalizedMobile === '') missingFields.push('mobilePhone');
+  if (normalizedMobile === '') missingFields.push('mobilePhoneAttribute');
 
   logger[missingFields.length > 0 ? 'warn' : 'info']('executeV2.validate.snapshot', {
     correlationId,
     missingFields,
     fieldsPresent: {
       message: normalizedMessage !== '',
-      mobilePhone: normalizedMobile !== ''
+      mobilePhoneAttribute: normalizedMobile !== ''
     }
   });
 

--- a/src/index.js
+++ b/src/index.js
@@ -124,13 +124,31 @@ function onDoneButtonClick() {
     activityFormHelpers.hideError()
   }
 
-  activity.metaData.isConfigured = true
-  activity.arguments.execute.inArguments = [
-    { message, firstNameAttribute, mobilePhoneAttribute }
+  const payload = activity || {}
+  const inArguments = [
+    {
+      message: message || 'Thank you for your purchase!',
+      firstNameAttribute:
+        firstNameAttribute || '{{Contact.Attribute.KarixWPTest.FirstName}}',
+      mobilePhoneAttribute
+    }
   ]
 
-  connection.trigger('updateActivity', activity)
-  console.log(`Activity has been updated. Activity: ${JSON.stringify(activity)}`)
+  payload.arguments = payload.arguments || {}
+  const existingExecute = payload.arguments.execute || {}
+  payload.arguments.execute = {
+    ...existingExecute,
+    inArguments,
+    timeout: 10000
+  }
+
+  payload.metaData = payload.metaData || {}
+  payload.metaData.isConfigured = true
+
+  activity = payload
+
+  connection.trigger('updateActivity', payload)
+  console.log(`Activity has been updated. Activity: ${JSON.stringify(payload)}`)
 }
 
 function onCancelButtonClick() {


### PR DESCRIPTION
## Summary
- update the custom activity UI to persist message and attribute tokens with a 10s timeout when configuring the step
- add explicit lifecycle handlers that validate required fields, persist the configuration, and expose clearer logging
- tighten execute logging and validation to surface missing lifecycle fields earlier while retaining existing provider flow

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68db617b80c88330b2eea1c260ad23e8