### PR TITLE
Handle lifecycle validation using nested execute arguments

### DIFF
--- a/app.js
+++ b/app.js
@@ -76,9 +76,15 @@ function acknowledgeLifecycleEvent(routeName) {
       requestBody: req.body
     });
     try {
-      if (req.body && Array.isArray(req.body.inArguments) && req.body.inArguments.length > 0) {
-        validateLifecycleRequest(req.body);
-        logger.debug(`${routeName} lifecycle payload validated successfully.`, {
+      const lifecycleArgs = req.body?.arguments?.execute;
+
+      if (
+        lifecycleArgs &&
+        Array.isArray(lifecycleArgs.inArguments) &&
+        lifecycleArgs.inArguments.length > 0
+      ) {
+        validateLifecycleRequest(lifecycleArgs);
+        logger.debug(`${routeName} lifecycle execute arguments validated successfully.`, {
           correlationId: req.correlationId
         });
       }

--- a/postman/sfmc-custom-activity.postman_collection.json
+++ b/postman/sfmc-custom-activity.postman_collection.json
@@ -127,6 +127,33 @@
           "response": []
         },
         {
+          "name": "Validate - missing mobilePhoneAttribute",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"arguments\": {\n    \"execute\": {\n      \"inArguments\": [\n        {\n          \"message\": \"Lifecycle validation regression test\"\n        }\n      ]\n    }\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/validate",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "validate"
+              ]
+            },
+            "description": "Expect a 400 response with validation errors when mobilePhoneAttribute is missing from the lifecycle execute arguments."
+          },
+          "response": []
+        },
+        {
           "name": "Stop",
           "request": {
             "method": "POST",


### PR DESCRIPTION
## Summary
- update lifecycle acknowledgement to validate nested execute arguments payloads
- keep lifecycle logging and clarify the success message now targets the execute arguments structure
- add a Postman regression request that expects a 400 when mobilePhoneAttribute is omitted from lifecycle execute arguments

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db7d9f5ef88330b85403762f476306