### PR TITLE
Fix parsing of Journey Builder inArguments arrays

### DIFF
--- a/lib/activity-validation.js
+++ b/lib/activity-validation.js
@@ -28,12 +28,18 @@ function parseInArguments(body) {
     throw new ValidationError('inArguments is required and must be a non-empty array.');
   }
 
-  const args = inArguments[0];
-  if (!args || typeof args !== 'object') {
-    throw new ValidationError('The first element in inArguments must be an object.');
+  const mergedArgs = inArguments.reduce((acc, current) => {
+    if (!current || typeof current !== 'object' || Array.isArray(current)) {
+      return acc;
+    }
+    return Object.assign(acc, current);
+  }, {});
+
+  if (Object.keys(mergedArgs).length === 0) {
+    throw new ValidationError('inArguments must contain at least one object with properties.');
   }
 
-  return args;
+  return mergedArgs;
 }
 
 function validateRequiredField(fieldName, value) {


### PR DESCRIPTION
## Summary
- merge inArguments array entries when validating lifecycle and execute payloads so all mapped values are available

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68db827d77888330839acbc030bee2f9