### PR TITLE
Handle nested execute inArguments and log data extension payload

### DIFF
--- a/app.js
+++ b/app.js
@@ -228,6 +228,10 @@ app.post('/executeV2', async (req, res) => {
     }
 
     logger.info('executeV2 journey data inspection.', journeyDataLog);
+    logger.info('executeV2 data extension payload received.', {
+      correlationId,
+      dataExtensionPayload: validatedArgs.rawArguments
+    });
 
     const providerPayload = buildDigoPayload(validatedArgs);
     logger.debug('executeV2 resolved values.', {

--- a/lib/activity-validation.js
+++ b/lib/activity-validation.js
@@ -18,12 +18,27 @@ function normalizeString(value) {
   return String(value).trim();
 }
 
-function parseInArguments(body) {
+function resolveInArguments(body) {
   if (!body || typeof body !== 'object') {
     throw new ValidationError('Request body must be a JSON object.');
   }
 
-  const { inArguments } = body;
+  if (Array.isArray(body.inArguments) && body.inArguments.length > 0) {
+    return body.inArguments;
+  }
+
+  const nested = body.arguments && body.arguments.execute && body.arguments.execute.inArguments;
+  if (Array.isArray(nested) && nested.length > 0) {
+    logger.info('Falling back to arguments.execute.inArguments payload.');
+    return nested;
+  }
+
+  return body.inArguments;
+}
+
+function parseInArguments(body) {
+  const inArguments = resolveInArguments(body);
+
   if (!Array.isArray(inArguments) || inArguments.length === 0) {
     throw new ValidationError('inArguments is required and must be a non-empty array.');
   }


### PR DESCRIPTION
## Summary
- allow execute payload parsing to fall back to `arguments.execute.inArguments` when the top-level `inArguments` array is absent so Data Extension data can still be read
- log the resolved execute payload at info level to help confirm Data Extension values are received from Journey Builder

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db9b199cfc8330a084c499c1c3c838