### PR TITLE
Block execute when unresolved journey fields are present

### DIFF
--- a/app.js
+++ b/app.js
@@ -213,6 +213,17 @@ app.post('/executeV2', async (req, res) => {
     });
 
     const { masked: rawArgumentsPreview, unresolvedFields } = inspectJourneyData(validatedArgs.rawArguments);
+
+    if (unresolvedFields.length > 0) {
+      logger.warn('executeV2 unresolved journey data fields detected.', {
+        correlationId,
+        unresolvedFields
+      });
+      throw new ValidationError(
+        `Unresolved journey data fields detected: ${unresolvedFields.join(', ')}`,
+        unresolvedFields.map((field) => `Unresolved field: ${field}`)
+      );
+    }
     const { masked: mappedValuesPreview } = inspectJourneyData(validatedArgs.mappedValues);
     const journeyDataLog = {
       correlationId,


### PR DESCRIPTION
## Summary
- fail executeV2 requests when journey data still contains unresolved fields
- log a warning and surface the unresolved field names via ValidationError

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dba1fcd00483309c7790a24a0beee2