### PR TITLE
Persist Journey tokens across custom activity lifecycle

### DIFF
--- a/config-json.js
+++ b/config-json.js
@@ -63,7 +63,8 @@ module.exports = function configJSON(req) {
         retryCount: 5,
         retryDelay: 1000,
         concurrentRequests: 5,
-        url: `${baseUrl}/executeV2`
+        url: `${baseUrl}/executeV2`,
+        useJwt: true
       }
     },
     configurationArguments: {

--- a/lib/activity-validation.js
+++ b/lib/activity-validation.js
@@ -66,7 +66,7 @@ function validateRequiredField(fieldName, value) {
 }
 
 function validateExecuteRequest(body) {
-  logger.debug('Validating execute request body (accepts mobilePhone or mobilePhoneAttribute).', { body });
+  logger.debug('Validating execute request body (accepts mobile, mobilePhone, or mobilePhoneAttribute).', { body });
   const args = parseInArguments(body);
   const errors = [];
 
@@ -75,7 +75,7 @@ function validateExecuteRequest(body) {
   if (messageError) errors.push(messageError);
 
   const mappedValuesArg = args.mappedValues;
-  let mobilePhoneSource = args.mobilePhone;
+  let mobilePhoneSource = args.mobilePhone !== undefined ? args.mobilePhone : args.mobile;
   let resolvedFromAttribute = false;
   if (
     mappedValuesArg &&
@@ -87,7 +87,7 @@ function validateExecuteRequest(body) {
   } else {
     const normalizedMobilePhone = normalizeString(mobilePhoneSource);
     if (normalizedMobilePhone === '') {
-      const normalizedAttribute = normalizeString(args.mobilePhoneAttribute);
+      const normalizedAttribute = normalizeString(args.mobilePhoneAttribute || args.mobile);
       if (normalizedAttribute !== '') {
         mobilePhoneSource = normalizedAttribute;
         resolvedFromAttribute = true;
@@ -139,8 +139,8 @@ function validateLifecycleRequest(body) {
   if (messageError) errors.push(messageError);
 
   const { value: mobilePhoneAttribute, error: mobilePhoneAttributeError } = validateRequiredField(
-    'mobilePhoneAttribute',
-    args.mobilePhoneAttribute
+    'mobilePhoneAttribute or mobile',
+    args.mobilePhoneAttribute || args.mobile
   );
   if (mobilePhoneAttributeError) errors.push(mobilePhoneAttributeError);
 


### PR DESCRIPTION
## Summary
- ensure the activity config exposes lifecycle URLs and enables JWT authentication on execute
- persist message, FirstName, mobile, and journey metadata in the Postmonger save payload so Journey Builder stores the tokens
- add lifecycle diagnostics and execute logging that merges incoming inArguments and records the resolved contact values

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68dba93075548330861509faf7f9e61b