### PR TITLE
Log masked inArguments preview during save lifecycle

### DIFF
--- a/app.js
+++ b/app.js
@@ -107,6 +107,22 @@ function acknowledgeLifecycleEvent(routeName) {
           correlationId: req.correlationId,
           inArgumentKeys: Object.keys(mergedInArguments)
         });
+
+        const { masked: maskedInArguments, unresolvedFields } = inspectJourneyData(mergedInArguments);
+
+        if (Object.keys(maskedInArguments).length > 0) {
+          logger.info('Save lifecycle inArguments preview.', {
+            correlationId: req.correlationId,
+            inArgumentsPreview: maskedInArguments
+          });
+        }
+
+        if (Array.isArray(unresolvedFields) && unresolvedFields.length > 0) {
+          logger.warn('Save lifecycle unresolved journey data fields detected.', {
+            correlationId: req.correlationId,
+            unresolvedFields
+          });
+        }
       } else {
         logger.warn('Save lifecycle received without inArguments.', { correlationId: req.correlationId });
       }

--- a/docs/testing-locally.md
+++ b/docs/testing-locally.md
@@ -15,3 +15,14 @@ npm start
 When testing locally, you are not able to interact with journey builder as you would if the app was iframed into the platform. For example, when you run locally, you'll notice there's no "Save" or "Cancel" button like you would expect in the platform, this is because those buttons are part of Journey Builder's UI and not the custom activity's - the two interact with each other using postmonger (ex. if you press "cancel" a message is triggered from JB -> custom activity to close the acivity). 
 
 In any case, a "mock" jb object ```jb``` is setup in the code so if you run locally, you can open the browser console and run ```jb.ready()```. This will instantiate the jb object. After doing so, if you populate the fields, you can run ```jb.save()``` and you'll see what the save payload looks like.
+
+## Inspecting inArguments in the Logs
+
+When Journey Builder invokes the **save** lifecycle the server now logs a preview of the inArguments that were received. Look for log lines similar to the following in your terminal output:
+
+```
+[2025-09-30T10:23:42.089Z] [INFO] Save lifecycle received inArguments. | meta={"correlationId":"<id>","inArgumentKeys":["message","mobilePhoneAttribute"]}
+[2025-09-30T10:23:42.089Z] [INFO] Save lifecycle inArguments preview. | meta={"correlationId":"<id>","inArgumentsPreview":{"message":"Thanks for your purchase!","mobilePhoneAttribute":"***1234"}}
+```
+
+The preview masks sensitive values (such as phone numbers) but confirms that data from the Data Extension reached the custom activity. If you see a warning that no inArguments were received, double-check the activity configuration inside Journey Builder.


### PR DESCRIPTION
## Summary
- add logging that surfaces a masked preview of inArguments when the save lifecycle runs
- document how to use the new log messages to confirm Data Extension data reached the custom activity

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbaff8493c833091c9a88b72c56674