### PR TITLE
Rename execute endpoint and remove hardcoded provider URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Express Server (app.js)
         │
         ├── Serves inspector UI (index.html + main.js)
         │
-        └── Runtime execution (POST /executeV2)
+        └── Runtime execution (POST /execute)
                 │
                 ├─► Activity Validation (lib/activity-validation.js)
                 │        │
@@ -32,7 +32,7 @@ Express Server (app.js)
 
 1. Journey Builder loads `/config.json` to render the Custom Activity on the canvas.
 2. The inspector iframe loads `index.html` and the bundled `main.js`, which use Postmonger to exchange data with Journey Builder.
-3. When a contact hits the activity, Journey Builder sends a POST to `/executeV2`.
+3. When a contact hits the activity, Journey Builder sends a POST to `/execute`.
 4. The server validates payloads, constructs the DIGO request, retries transient failures, and returns status metadata to Journey Builder.
 
 ## Getting Started
@@ -77,7 +77,7 @@ Use the inspector's attribute picker to map Data Extension values into the activ
 | `PUBLIC_BASE_URL` | Fully qualified base URL used to generate config links (overrides proxy-derived host/protocol). |
 | `PORT` | Express listen port (defaults to `3001`). |
 | `LOG_LEVEL` | Minimum log level (`debug`, `info`, `warn`, `error`). Defaults to `info`. |
-| `DIGO_API_URL` | Provider API endpoint (`https://sfmc.comsensetechnologies.com/api/message` by default). |
+| `DIGO_API_URL` | Provider API endpoint. Must be configured for outbound requests. |
 | `COMSENSE_BASIC_AUTH` | Base64-encoded `username:password` string used for HTTP Basic authentication. |
 | `DIGO_HTTP_TIMEOUT_MS` | HTTP timeout in milliseconds (default `15000`). |
 | `DIGO_RETRY_ATTEMPTS` | Maximum retry attempts on transient errors (default `3`). |
@@ -97,7 +97,7 @@ Use the inspector's attribute picker to map Data Extension values into the activ
 | Symptom | Suggested Checks |
 | --- | --- |
 | Journey Builder inspector fails to load | Confirm `/config.json` responds with 200 and that `PUBLIC_BASE_URL` resolves correctly. Inspect browser console for Postmonger errors. |
-| `/executeV2` returns `status: 'invalid'` | Review the JSON response `details` array and ensure Journey data extensions map required fields. Logs include correlation IDs for tracing. |
+| `/execute` returns `status: 'invalid'` | Review the JSON response `details` array and ensure Journey data extensions map required fields. Logs include correlation IDs for tracing. |
 | Provider request failures | Validate provider credentials (e.g., `COMSENSE_BASIC_AUTH`) and network reachability. When `DIGO_STUB_MODE` is `true`, outbound calls are skipped. |
 | Missing SMS recipients | Provide `dataSet` in Journey mappings or configure `DIGO_DEFAULT_MSISDNS`. |
 | Logs not appearing | Check `LOG_LEVEL` and your hosting platform's log drain or console. |

--- a/app.js
+++ b/app.js
@@ -244,10 +244,10 @@ function inspectJourneyData(rawArguments) {
   return { masked, unresolvedFields };
 }
 
-app.post('/executeV2', async (req, res) => {
+app.post('/execute', async (req, res) => {
   const correlationId = req.correlationId;
-  logger.info('executeV2 invoked.', { correlationId });
-  logger.debug('executeV2 request payload received.', {
+  logger.info('execute invoked.', { correlationId });
+  logger.debug('execute request payload received.', {
     correlationId,
     requestBody: req.body
   });
@@ -279,7 +279,7 @@ app.post('/executeV2', async (req, res) => {
   });
 
   if (missingInArgumentKeys.length > 0) {
-    logger.warn('executeV2 missing expected inArguments.', {
+    logger.warn('execute missing expected inArguments.', {
       correlationId,
       missingInArgumentKeys
     });
@@ -303,7 +303,7 @@ app.post('/executeV2', async (req, res) => {
           rawArgs.contactKey || rawArgs.ContactKey || rawArgs.contactId || normalizedPreview.contactKey;
       }
     }
-    logger.debug('executeV2 request payload validated.', {
+    logger.debug('execute request payload validated.', {
       correlationId,
       validationResult: {
         message: validatedArgs.message,
@@ -316,7 +316,7 @@ app.post('/executeV2', async (req, res) => {
     const { masked: rawArgumentsPreview, unresolvedFields } = inspectJourneyData(validatedArgs.rawArguments);
 
     if (unresolvedFields.length > 0) {
-      logger.warn('executeV2 unresolved journey data fields detected.', {
+      logger.warn('execute unresolved journey data fields detected.', {
         correlationId,
         unresolvedFields
       });
@@ -339,14 +339,14 @@ app.post('/executeV2', async (req, res) => {
       journeyDataLog.unresolvedFields = unresolvedFields;
     }
 
-    logger.info('executeV2 journey data inspection.', journeyDataLog);
-    logger.info('executeV2 data extension payload received.', {
+    logger.info('execute journey data inspection.', journeyDataLog);
+    logger.info('execute data extension payload received.', {
       correlationId,
       dataExtensionPayload: validatedArgs.rawArguments
     });
 
     const providerPayload = buildDigoPayload(validatedArgs);
-    logger.debug('executeV2 resolved values.', {
+    logger.debug('execute resolved values.', {
       correlationId,
       resolved: {
         message: validatedArgs.message,
@@ -384,7 +384,7 @@ app.post('/executeV2', async (req, res) => {
       }
     });
 
-    logger.debug('executeV2 provider payload built.', {
+    logger.debug('execute provider payload built.', {
       correlationId,
       payload: providerPayload
     });
@@ -394,13 +394,13 @@ app.post('/executeV2', async (req, res) => {
       correlationId
     });
 
-    logger.info('executeV2 provider response received.', {
+    logger.info('execute provider response received.', {
       correlationId,
       providerStatus: providerResponse.status,
       providerResponse: providerResponse.data
     });
 
-    logger.info('executeV2 resolved inArguments.', {
+    logger.info('execute resolved inArguments.', {
       correlationId,
       resolvedInArguments: normalizedPreview
     });
@@ -412,7 +412,7 @@ app.post('/executeV2', async (req, res) => {
     });
   } catch (error) {
     if (error instanceof ValidationError) {
-      logger.warn('executeV2 validation failed.', { errors: error.details, correlationId });
+      logger.warn('execute validation failed.', { errors: error.details, correlationId });
       return res.status(error.statusCode).json({
         status: 'invalid',
         message: error.message,
@@ -421,7 +421,7 @@ app.post('/executeV2', async (req, res) => {
     }
 
     if (error instanceof ProviderRequestError) {
-      logger.error('executeV2 provider call failed.', {
+      logger.error('execute provider call failed.', {
         correlationId,
         details: error.details
       });
@@ -433,7 +433,7 @@ app.post('/executeV2', async (req, res) => {
       });
     }
 
-    logger.error('executeV2 unexpected error.', { correlationId, message: error.message });
+    logger.error('execute unexpected error.', { correlationId, message: error.message });
     return res.status(500).json({
       status: 'error',
       message: 'Unexpected error executing activity.'

--- a/config-json.js
+++ b/config-json.js
@@ -63,7 +63,7 @@ module.exports = function configJSON(req) {
         retryCount: 5,
         retryDelay: 1000,
         concurrentRequests: 5,
-        url: `${baseUrl}/executeV2`,
+        url: `${baseUrl}/execute`,
         useJwt: true
       }
     },

--- a/docs/files/app.js.md
+++ b/docs/files/app.js.md
@@ -8,7 +8,7 @@ Server-side entry point that exposes the Express application used by the Salesfo
 | Function / Route | Description |
 | --- | --- |
 | `acknowledgeLifecycleEvent(routeName)` | Higher-order helper that generates Express handlers for Journey Builder lifecycle routes (`/save`, `/publish`, `/validate`, `/stop`). |
-| `app.post('/executeV2', handler)` | Main execution endpoint invoked by Journey Builder during contact processing. Validates input, builds a DIGO payload, and calls the provider API. |
+| `app.post('/execute', handler)` | Main execution endpoint invoked by Journey Builder during contact processing. Validates input, builds a DIGO payload, and calls the provider API. |
 | `app.get('/config.json', handler)` | Provides the dynamic Custom Activity configuration consumed by Journey Builder. |
 | Static asset routes (`/`, `/index.html`, `/main.js`, `/main.js.map`, `/assets`, `/images`) | Serve the client-side inspector UI and supporting assets. |
 | `app.get('/health')` | Lightweight health check used by deployment platforms. |
@@ -16,7 +16,7 @@ Server-side entry point that exposes the Express application used by the Salesfo
 ## Key Parameters and Return Types
 
 * Lifecycle handlers expect SFMC lifecycle payloads (`req.body`) that contain optional `inArguments`. Successful validations return `{ status: 'ok' }`; validation failures return `{ status: 'invalid', message, details }` with HTTP 400.
-* `/executeV2` expects a Marketing Cloud execute payload (`req.body`). After validation it returns `{ status: 'ok', providerStatus, providerResponse }` on success. Validation failures respond with HTTP 400, provider issues respond with HTTP 4xx/5xx plus `{ status: 'provider_error', message, details }`, and unexpected failures respond with HTTP 500 and `{ status: 'error', message }`.
+* `/execute` expects a Marketing Cloud execute payload (`req.body`). After validation it returns `{ status: 'ok', providerStatus, providerResponse }` on success. Validation failures respond with HTTP 400, provider issues respond with HTTP 4xx/5xx plus `{ status: 'provider_error', message, details }`, and unexpected failures respond with HTTP 500 and `{ status: 'error', message }`.
 
 ## External Dependencies
 
@@ -33,7 +33,7 @@ Server-side entry point that exposes the Express application used by the Salesfo
 
 1. Incoming HTTP requests receive a correlation ID (header `X-Correlation-Id`).
 2. Lifecycle requests are optionally validated and return acknowledgement JSON to Journey Builder.
-3. `/executeV2` validates incoming Journey execute payloads, builds the DIGO payload (including message content and mapped values), logs a debug preview, and forwards it to the DIGO API via `sendPayloadWithRetry`.
+3. `/execute` validates incoming Journey execute payloads, builds the DIGO payload (including message content and mapped values), logs a debug preview, and forwards it to the DIGO API via `sendPayloadWithRetry`.
 4. Provider responses (or errors) are mapped back to SFMC-compatible JSON responses.
 
 ## Error Handling and Edge Cases
@@ -46,7 +46,7 @@ Server-side entry point that exposes the Express application used by the Salesfo
 ## Usage Example
 
 ```
-POST /executeV2
+POST /execute
 Content-Type: application/json
 X-Correlation-Id: 12345
 

--- a/docs/files/config-json.js.md
+++ b/docs/files/config-json.js.md
@@ -23,7 +23,7 @@ Generates the `config.json` payload consumed by SFMC Journey Builder when loadin
 ## Data Flow
 
 1. `resolveBaseUrl` inspects `PUBLIC_BASE_URL`, `x-forwarded-proto`, `req.protocol`, and `host` headers to infer deployment URL.
-2. The base URL seeds icon locations and webhook endpoints for lifecycle (`/save`, `/publish`, `/validate`, `/stop`) and execute (`/executeV2`).
+2. The base URL seeds icon locations and webhook endpoints for lifecycle (`/save`, `/publish`, `/validate`, `/stop`) and execute (`/execute`).
 3. Schema definitions describe expected Journey Builder inArguments (`message`, `firstNameAttribute`, `mobilePhoneAttribute`), informing Journey validation.
 
 ## Error Handling and Edge Cases

--- a/docs/files/lib/digo-client.js.md
+++ b/docs/files/lib/digo-client.js.md
@@ -26,7 +26,7 @@ Handles outbound HTTP communication with the DIGO SMS provider, adding retry log
 * `axios` for HTTP requests (can be replaced via `options.httpClient`).
 * `./logger` for trace logging.
 * Environment variables read by `getConfig()`:
-  * `DIGO_API_URL` – Provider endpoint (default `https://sfmc.comsensetechnologies.com/api/message`).
+  * `DIGO_API_URL` – Provider endpoint. Must be set for outbound delivery.
   * `COMSENSE_BASIC_AUTH` – Base64 `username:password` credential applied to the `Authorization` header.
   * `DIGO_HTTP_TIMEOUT_MS` – Request timeout in milliseconds (default `15000`).
   * `DIGO_RETRY_ATTEMPTS` – Number of retries (default `3`).
@@ -67,7 +67,7 @@ try {
 
 ## Related Files
 
-* Called by `/executeV2` in `app.js` to deliver DIGO payloads.
+* Called by `/execute` in `app.js` to deliver DIGO payloads.
 * Consumes payloads built in `lib/digo-payload.js`.
 * Logging relies on `lib/logger.js`.
 

--- a/docs/files/lib/digo-payload.js.md
+++ b/docs/files/lib/digo-payload.js.md
@@ -76,7 +76,7 @@ Resulting payload snippet:
 
 * Consumes validated input from `lib/activity-validation.js`.
 * Output is sent via `sendPayloadWithRetry` in `lib/digo-client.js`.
-* Called by `/executeV2` in `app.js`.
+* Called by `/execute` in `app.js`.
 
 ## Troubleshooting
 

--- a/docs/files/lib/logger.js.md
+++ b/docs/files/lib/logger.js.md
@@ -38,7 +38,7 @@ Provides a lightweight, leveled logging utility for both server routes and provi
 ```js
 const logger = require('./lib/logger');
 
-logger.info('executeV2 invoked', { correlationId: 'abc-123' });
+logger.info('execute invoked', { correlationId: 'abc-123' });
 logger.error('Provider call failed', { attempt: 2, status: 500 });
 ```
 

--- a/lib/digo-client.js
+++ b/lib/digo-client.js
@@ -14,7 +14,7 @@ class ProviderRequestError extends Error {
 
 function getConfig() {
   return {
-    url: process.env.DIGO_API_URL || 'https://sfmc.comsensetechnologies.com/api/message',
+    url: process.env.DIGO_API_URL,
     basicAuth: process.env.COMSENSE_BASIC_AUTH,
     timeout: Number(process.env.DIGO_HTTP_TIMEOUT_MS || 15000),
     retryAttempts: Number(process.env.DIGO_RETRY_ATTEMPTS || 3),
@@ -44,6 +44,13 @@ async function sendPayloadWithRetry(payload, options = {}) {
   const client = options.httpClient || axios;
   const headers = { ...buildHeaders(config), ...(options.headers || {}) };
   const correlationId = options.correlationId;
+
+  if (!config.url) {
+    throw new ProviderRequestError('Provider URL not configured.', 500, {
+      correlationId,
+      hint: 'Set the DIGO_API_URL environment variable to enable provider requests.'
+    });
+  }
 
   logger.debug('Preparing provider request.', {
     correlationId,

--- a/postman/sfmc-custom-activity.postman_collection.json
+++ b/postman/sfmc-custom-activity.postman_collection.json
@@ -182,10 +182,10 @@
       ]
     },
     {
-      "name": "Execution",
-      "item": [
-        {
-          "name": "ExecuteV2",
+        "name": "Execution",
+        "item": [
+          {
+            "name": "Execute",
           "request": {
             "method": "POST",
             "header": [
@@ -199,12 +199,12 @@
               "raw": "{\n  \"inArguments\": [\n    {\n      \"message\": \"Thank you for your purchase!\",\n      \"firstNameAttribute\": \"{{Contact.Attribute.MyDE.FirstName}}\",\n      \"mobilePhoneAttribute\": \"{{Contact.Attribute.MyDE.mobile}}\"\n    }\n  ]\n}"
             },
             "url": {
-              "raw": "{{baseUrl}}/executeV2",
+              "raw": "{{baseUrl}}/execute",
               "host": [
                 "{{baseUrl}}"
               ],
               "path": [
-                "executeV2"
+                "execute"
               ]
             }
           },


### PR DESCRIPTION
## Summary
- rename the Journey Builder execute endpoint and related documentation from `/executeV2` to `/execute`
- require an explicit `DIGO_API_URL` configuration and guard outbound calls when it is missing
- refresh supporting documentation and tooling references to match the new endpoint naming

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbb1df7e7483309f14ce87ffea3352