### PR TITLE
Add static test data fixtures for lifecycle and execute testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ Use the inspector's attribute picker to map Data Extension values into the activ
 * `npm test` – Placeholder script (update when automated tests are added).
 * Postman collection: `postman/sfmc-custom-activity.postman_collection.json` includes requests for every endpoint.
 
+### Static Test Data Mode
+
+Local testing outside of Journey Builder often lacks resolved journey attributes. Enable deterministic fixture values by setting
+`ENABLE_STATIC_TEST_DATA=true` (environment variable) or by sending the `X-Use-Static-Test-Data: true` header / `useStaticTestData`
+flag in the request body. When enabled, lifecycle (`/validate`, `/save`, `/publish`, `/stop`) and `/execute` requests receive
+default message, contact, and mapped values so validation succeeds without SFMC token resolution.
+
 ## Environment Variables
 
 | Variable | Description |
@@ -86,6 +93,7 @@ Use the inspector's attribute picker to map Data Extension values into the activ
 | `DIGO_DEFAULT_MSISDNS` | Comma-separated fallback MSISDN list when Journey data lacks recipients. |
 | `DIGO_ORIGINATOR` | SMS originator/sender ID (default `TACMPN`). |
 | `DIGO_STUB_MODE` | When set to `true`, skips outbound DIGO calls and returns stub responses (ideal for testing). |
+| `ENABLE_STATIC_TEST_DATA` | When `true`, injects static fixture values into lifecycle and execute requests for local testing. |
 
 ## Deployment Notes
 
@@ -121,6 +129,7 @@ Detailed documentation is available for every source file under `docs/files/`:
 * [`lib/activity-validation.js`](docs/files/lib/activity-validation.js.md)
 * [`lib/digo-payload.js`](docs/files/lib/digo-payload.js.md)
 * [`lib/digo-client.js`](docs/files/lib/digo-client.js.md)
+* [`lib/static-test-data.js`](docs/files/lib/static-test-data.js.md)
 * [`src/index.js`](docs/files/src/index.js.md)
 * [`index.html`](docs/files/index.html.md)
 * [`webpack.config.js`](docs/files/webpack.config.js.md)

--- a/app.js
+++ b/app.js
@@ -19,6 +19,10 @@ const {
   validateExecuteRequest,
   validateLifecycleRequest
 } = require('./lib/activity-validation');
+const {
+  applyLifecycleStaticTestData,
+  applyExecuteStaticTestData
+} = require('./lib/static-test-data');
 const { buildDigoPayload } = require('./lib/digo-payload');
 const { sendPayloadWithRetry, ProviderRequestError } = require('./lib/digo-client');
 
@@ -95,6 +99,14 @@ function mergeInArgumentsFromRequest(body) {
 function acknowledgeLifecycleEvent(routeName) {
   return (req, res) => {
     logger.info(`${routeName} lifecycle hook invoked.`, { correlationId: req.correlationId });
+
+    const staticDataApplied = applyLifecycleStaticTestData(req);
+    if (staticDataApplied) {
+      logger.debug(`${routeName} lifecycle static test data merged into request body.`, {
+        correlationId: req.correlationId
+      });
+    }
+
     logger.debug(`${routeName} lifecycle payload received.`, {
       correlationId: req.correlationId,
       requestBody: req.body
@@ -247,6 +259,12 @@ function inspectJourneyData(rawArguments) {
 app.post('/execute', async (req, res) => {
   const correlationId = req.correlationId;
   logger.info('execute invoked.', { correlationId });
+
+  const staticDataApplied = applyExecuteStaticTestData(req);
+  if (staticDataApplied) {
+    logger.debug('execute static test data merged into request body.', { correlationId });
+  }
+
   logger.debug('execute request payload received.', {
     correlationId,
     requestBody: req.body

--- a/docs/files/app.js.md
+++ b/docs/files/app.js.md
@@ -15,8 +15,8 @@ Server-side entry point that exposes the Express application used by the Salesfo
 
 ## Key Parameters and Return Types
 
-* Lifecycle handlers expect SFMC lifecycle payloads (`req.body`) that contain optional `inArguments`. Successful validations return `{ status: 'ok' }`; validation failures return `{ status: 'invalid', message, details }` with HTTP 400.
-* `/execute` expects a Marketing Cloud execute payload (`req.body`). After validation it returns `{ status: 'ok', providerStatus, providerResponse }` on success. Validation failures respond with HTTP 400, provider issues respond with HTTP 4xx/5xx plus `{ status: 'provider_error', message, details }`, and unexpected failures respond with HTTP 500 and `{ status: 'error', message }`.
+* Lifecycle handlers expect SFMC lifecycle payloads (`req.body`) that contain optional `inArguments`. Successful validations return `{ status: 'ok' }`; validation failures return `{ status: 'invalid', message, details }` with HTTP 400. When static test mode is enabled (environment variable `ENABLE_STATIC_TEST_DATA` or request flag `useStaticTestData`), deterministic fixture values are injected before validation so development requests can succeed without resolved Journey tokens.
+* `/execute` expects a Marketing Cloud execute payload (`req.body`). After validation it returns `{ status: 'ok', providerStatus, providerResponse }` on success. Validation failures respond with HTTP 400, provider issues respond with HTTP 4xx/5xx plus `{ status: 'provider_error', message, details }`, and unexpected failures respond with HTTP 500 and `{ status: 'error', message }`. Static test mode uses the same fixture mechanism to populate message, contact, and mapped values before validation runs.
 
 ## External Dependencies
 
@@ -28,6 +28,7 @@ Server-side entry point that exposes the Express application used by the Salesfo
 * `./lib/activity-validation` for request validation and error types.
 * `./lib/digo-payload` to assemble the provider request body.
 * `./lib/digo-client` to send payloads with retry logic.
+* `./lib/static-test-data` to optionally merge deterministic fixture values into requests during local testing.
 
 ## Data Flow
 

--- a/docs/files/lib/static-test-data.js.md
+++ b/docs/files/lib/static-test-data.js.md
@@ -1,0 +1,32 @@
+# `lib/static-test-data.js`
+
+Utility module that injects deterministic fixture values into lifecycle and execute requests when static test mode is enabled. These helpers make it possible to exercise the Custom Activity locally without relying on Journey Builder to resolve attribute tokens.
+
+## Exports
+
+| Function | Description |
+| --- | --- |
+| `shouldUseStaticTestData(req)` | Evaluates headers, query parameters, body flags, or the `ENABLE_STATIC_TEST_DATA` environment variable to determine whether static fixtures should be merged. |
+| `applyLifecycleStaticTestData(req)` | Populates lifecycle payloads with default message and phone attributes before validation when static mode is enabled. |
+| `applyExecuteStaticTestData(req)` | Populates execute payloads (message, contact fields, mapped values) before validation when static mode is enabled. |
+| `STATIC_LIFECYCLE_ARGUMENTS` | Exported fixture map used for lifecycle requests. |
+| `STATIC_EXECUTE_ARGUMENTS` | Exported fixture map used for execute requests. |
+
+## How It Works
+
+1. `shouldUseStaticTestData` checks (in order) the `X-Use-Static-Test-Data` header, `useStaticTestData` query parameter, request body flag, and the `ENABLE_STATIC_TEST_DATA` environment variable.
+2. When enabled, `apply*` helpers ensure `req.body.inArguments` and `req.body.arguments.execute.inArguments` share a primary object to avoid mutating production payload shapes.
+3. Default values override missing, blank, or tokenized (`{{...}}`) fields without touching values that are already resolved.
+4. The merge is logged at `info` level so developers can trace when fixtures were applied.
+
+## Usage Tips
+
+* Enable the mode globally by exporting `ENABLE_STATIC_TEST_DATA=true` before starting the Express app, or toggle per-request with the header/body flag.
+* The fixture data is limited to basic contact details suitable for validation; it does not attempt to mimic full provider responses—combine it with `DIGO_STUB_MODE` to bypass outbound calls entirely during development.
+* Because the helpers only fill gaps, you can still supply explicit values in the request body to override specific fixture fields when testing edge cases.
+
+## Related Files
+
+* [`app.js`](../app.js.md) – Calls the helpers before handling lifecycle and execute requests.
+* [`lib/activity-validation.js`](activity-validation.js.md) – Performs the validation logic that relies on the merged arguments.
+* [`lib/digo-payload.js`](digo-payload.js.md) – Consumes validated arguments when building the provider payload.

--- a/lib/static-test-data.js
+++ b/lib/static-test-data.js
@@ -1,0 +1,237 @@
+'use strict';
+
+const logger = require('./logger');
+const { normalizeString } = require('./activity-validation');
+
+const STATIC_TEST_MOBILE = '+15555550123';
+const STATIC_TEST_FIRST_NAME = 'Journey Tester';
+const STATIC_TEST_CONTACT_KEY = 'static-contact-key';
+const STATIC_TEST_JOURNEY_ID = 'static-journey-id';
+const STATIC_TEST_ACTIVITY_ID = 'static-activity-id';
+
+const STATIC_LIFECYCLE_ARGUMENTS = {
+  message: 'Lifecycle validation regression test',
+  messageText: 'Lifecycle validation regression test',
+  mobilePhoneAttribute: STATIC_TEST_MOBILE,
+  mobile: STATIC_TEST_MOBILE
+};
+
+const STATIC_EXECUTE_ARGUMENTS = {
+  message: 'Thank you for your purchase!',
+  messageText: 'Thank you for your purchase!',
+  FirstName: STATIC_TEST_FIRST_NAME,
+  firstName: STATIC_TEST_FIRST_NAME,
+  firstNameAttribute: STATIC_TEST_FIRST_NAME,
+  mobile: STATIC_TEST_MOBILE,
+  mobilePhone: STATIC_TEST_MOBILE,
+  mobilePhoneAttribute: STATIC_TEST_MOBILE,
+  contactKey: STATIC_TEST_CONTACT_KEY,
+  ContactKey: STATIC_TEST_CONTACT_KEY,
+  journeyId: STATIC_TEST_JOURNEY_ID,
+  activityId: STATIC_TEST_ACTIVITY_ID,
+  mappedValues: {
+    firstName: STATIC_TEST_FIRST_NAME,
+    mobilePhone: STATIC_TEST_MOBILE
+  }
+};
+
+const TRUE_FLAG_VALUES = new Set(['true', '1', 'yes', 'on']);
+
+function shouldUseStaticTestData(req) {
+  if (!req || typeof req !== 'object') {
+    return false;
+  }
+
+  const { headers = {}, query = {}, body = {} } = req;
+
+  const headerFlag = typeof headers['x-use-static-test-data'] === 'string'
+    ? headers['x-use-static-test-data']
+    : headers['X-Use-Static-Test-Data'];
+
+  if (typeof headerFlag === 'string' && TRUE_FLAG_VALUES.has(headerFlag.toLowerCase())) {
+    return true;
+  }
+
+  const queryValue = query && typeof query.useStaticTestData === 'string'
+    ? query.useStaticTestData
+    : undefined;
+  if (typeof queryValue === 'string' && TRUE_FLAG_VALUES.has(queryValue.toLowerCase())) {
+    return true;
+  }
+
+  if (body &&
+    ((typeof body.useStaticTestData === 'string' && TRUE_FLAG_VALUES.has(body.useStaticTestData.toLowerCase())) ||
+      body.useStaticTestData === true)) {
+    return true;
+  }
+
+  if (process.env.ENABLE_STATIC_TEST_DATA && TRUE_FLAG_VALUES.has(process.env.ENABLE_STATIC_TEST_DATA.toLowerCase())) {
+    return true;
+  }
+
+  return false;
+}
+
+function isPlainObject(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function ensurePlainObjectAtIndex(arr) {
+  if (!Array.isArray(arr)) {
+    return null;
+  }
+
+  if (arr.length === 0) {
+    arr.push({});
+  }
+
+  if (!isPlainObject(arr[0])) {
+    arr[0] = {};
+  }
+
+  return arr[0];
+}
+
+function shouldApplyDefault(currentValue) {
+  if (currentValue === undefined || currentValue === null) {
+    return true;
+  }
+
+  if (typeof currentValue === 'string') {
+    const normalized = normalizeString(currentValue);
+    if (normalized === '') {
+      return true;
+    }
+
+    if (normalized.startsWith('{{') && normalized.endsWith('}}')) {
+      return true;
+    }
+
+    return false;
+  }
+
+  if (isPlainObject(currentValue) && Object.keys(currentValue).length === 0) {
+    return true;
+  }
+
+  return false;
+}
+
+function mergeDefaults(target, defaults) {
+  if (!isPlainObject(target) || !isPlainObject(defaults)) {
+    return false;
+  }
+
+  let applied = false;
+
+  Object.entries(defaults).forEach(([key, value]) => {
+    if (isPlainObject(value)) {
+      if (!isPlainObject(target[key])) {
+        target[key] = {};
+        applied = true;
+      }
+      if (mergeDefaults(target[key], value)) {
+        applied = true;
+      }
+      return;
+    }
+
+    if (shouldApplyDefault(target[key])) {
+      target[key] = value;
+      applied = true;
+    }
+  });
+
+  return applied;
+}
+
+function ensureInArgumentsContainers(body) {
+  if (!body || typeof body !== 'object') {
+    return [];
+  }
+
+  let nestedArray =
+    body.arguments &&
+    body.arguments.execute &&
+    Array.isArray(body.arguments.execute.inArguments)
+      ? body.arguments.execute.inArguments
+      : null;
+
+  if (!Array.isArray(body.inArguments) || body.inArguments.length === 0) {
+    if (nestedArray) {
+      body.inArguments = nestedArray;
+    } else {
+      body.inArguments = [{}];
+    }
+  }
+
+  const directContainer = ensurePlainObjectAtIndex(body.inArguments);
+
+  if (!nestedArray || nestedArray.length === 0) {
+    if (!body.arguments || typeof body.arguments !== 'object') {
+      body.arguments = {};
+    }
+
+    if (!body.arguments.execute || typeof body.arguments.execute !== 'object') {
+      body.arguments.execute = {};
+    }
+
+    body.arguments.execute.inArguments = body.inArguments;
+    nestedArray = body.arguments.execute.inArguments;
+  }
+
+  const nestedContainer = ensurePlainObjectAtIndex(nestedArray);
+
+  const containers = [directContainer];
+
+  if (nestedContainer && nestedContainer !== directContainer) {
+    containers.push(nestedContainer);
+  }
+
+  return containers;
+}
+
+function applyStaticDefaults(req, defaults, contextLabel) {
+  if (!shouldUseStaticTestData(req)) {
+    return false;
+  }
+
+  const body = req.body;
+  if (!body || typeof body !== 'object') {
+    logger.warn(`Static test data requested for ${contextLabel}, but request body is invalid.`);
+    return false;
+  }
+
+  const containers = ensureInArgumentsContainers(body);
+  let applied = false;
+
+  containers.forEach((target) => {
+    if (mergeDefaults(target, defaults)) {
+      applied = true;
+    }
+  });
+
+  if (applied) {
+    logger.info(`Static test data applied for ${contextLabel} request.`, {
+      correlationId: req.correlationId
+    });
+  }
+
+  return applied;
+}
+
+function applyLifecycleStaticTestData(req) {
+  return applyStaticDefaults(req, STATIC_LIFECYCLE_ARGUMENTS, 'lifecycle');
+}
+
+function applyExecuteStaticTestData(req) {
+  return applyStaticDefaults(req, STATIC_EXECUTE_ARGUMENTS, 'execute');
+}
+
+module.exports = {
+  shouldUseStaticTestData,
+  applyLifecycleStaticTestData,
+  applyExecuteStaticTestData,
+  STATIC_LIFECYCLE_ARGUMENTS,
+  STATIC_EXECUTE_ARGUMENTS
+};


### PR DESCRIPTION
## Summary
- add a static-test-data helper that can merge deterministic fallback inArguments when static mode is requested
- call the helper from lifecycle and execute routes so local requests can validate without resolved Journey tokens
- document the new testing mode and fixtures in the README and module docs

## Testing
- node -e "require('./lib/static-test-data'); console.log('static-test-data loaded');"

------
https://chatgpt.com/codex/tasks/task_e_68dbc78459b883308ea671e0f110efcd