### PR TITLE
Allow overriding Application Extension ID via request metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ default message, contact, and mapped values so validation succeeds without SFMC 
 | Variable | Description |
 | --- | --- |
 | `PUBLIC_BASE_URL` | Fully qualified base URL used to generate config links (overrides proxy-derived host/protocol). |
-| `APPLICATION_EXTENSION_ID` | Journey Builder **Application Extension ID** generated when installing the Custom Activity package. Required for canvas validation. |
+| `APPLICATION_EXTENSION_ID` | Journey Builder **Application Extension ID** generated when installing the Custom Activity package. Required for canvas validation. May also be supplied via the `x-application-extension-id` header or `applicationExtensionId` query string on `/config.json` for local tooling. |
 | `PORT` | Express listen port (defaults to `3001`). |
 | `LOG_LEVEL` | Minimum log level (`debug`, `info`, `warn`, `error`). Defaults to `info`. |
 | `DIGO_API_URL` | Provider API endpoint. Must be configured for outbound requests. |

--- a/config-json.js
+++ b/config-json.js
@@ -37,10 +37,31 @@ function resolveBaseUrl(req) {
   return `${protocol}://${host}`;
 }
 
+function resolveApplicationExtensionId(req) {
+  const envValue = process.env.APPLICATION_EXTENSION_ID;
+  if (envValue) {
+    return envValue;
+  }
+
+  if (req && typeof req.get === 'function') {
+    const headerValue = req.get('x-application-extension-id');
+    if (headerValue && headerValue.trim()) {
+      return headerValue.trim();
+    }
+  }
+
+  const queryValue = req?.query?.applicationExtensionId;
+  if (typeof queryValue === 'string' && queryValue.trim()) {
+    return queryValue.trim();
+  }
+
+  return '';
+}
+
 module.exports = function configJSON(req) {
   const baseUrl = resolveBaseUrl(req);
   const iconUrl = `${baseUrl}/images/iconSmall.svg`;
-  const applicationExtensionId = process.env.APPLICATION_EXTENSION_ID;
+  const applicationExtensionId = resolveApplicationExtensionId(req);
 
   if (!applicationExtensionId) {
     throw new Error(

--- a/docs/files/config-json.js.md
+++ b/docs/files/config-json.js.md
@@ -8,6 +8,7 @@ Generates the `config.json` payload consumed by SFMC Journey Builder when loadin
 | Function | Description |
 | --- | --- |
 | `resolveBaseUrl(req)` | Determines the fully qualified base URL used to assemble asset and webhook endpoints, favoring `PUBLIC_BASE_URL` before deriving from the incoming request. |
+| `resolveApplicationExtensionId(req)` | Resolves the Application Extension ID from the environment, headers, or query string. |
 | `module.exports = function configJSON(req)` | Builds and returns the Custom Activity configuration object expected by Journey Builder. |
 
 ## Key Parameters and Return Types
@@ -17,7 +18,7 @@ Generates the `config.json` payload consumed by SFMC Journey Builder when loadin
 
 ## External Dependencies
 
-* Relies on process environment variables: `PUBLIC_BASE_URL` to override base URL detection and `APPLICATION_EXTENSION_ID` to satisfy Journey Builder validation.
+* Relies on process environment variables: `PUBLIC_BASE_URL` to override base URL detection and `APPLICATION_EXTENSION_ID` to satisfy Journey Builder validation. The extension identifier can also be supplied via the `x-application-extension-id` header or `applicationExtensionId` query string when the environment variable is not set (useful for local testing tools).
 * References static assets stored under `/images`.
 
 ## Data Flow


### PR DESCRIPTION
## Summary
- allow the config endpoint to resolve the Application Extension ID from either the environment, an incoming header, or a query string parameter
- document the override options for local tooling in the README and config-json reference documentation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbcb3a27f48330ae728c03dc5e0a94