### PR TITLE
Fix static image asset routing

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,7 +39,7 @@ app.set('port', process.env.PORT || 3001);
 app.use(bodyParser.json({ limit: '1mb' }));
 app.use(express.static(path.join(__dirname, 'dist')));
 app.use('/assets', express.static(designSystemAssetsPath));
-app.use('/images', express.static(path.join(__dirname, 'images')));
+app.use('/images', express.static(path.join(__dirname, 'image')));
 
 // Attach a correlation id for every request so that logs are traceable.
 app.use((req, res, next) => {


### PR DESCRIPTION
## Summary
- serve the image assets directory under the correct folder so config and inspector icons load properly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbd7acb6808330add3ea8446c4ad83