### PR TITLE
Handle additional Journey Builder extension headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ default message, contact, and mapped values so validation succeeds without SFMC 
 | Variable | Description |
 | --- | --- |
 | `PUBLIC_BASE_URL` | Fully qualified base URL used to generate config links (overrides proxy-derived host/protocol). |
-| `APPLICATION_EXTENSION_ID` | Journey Builder **Application Extension ID** generated when installing the Custom Activity package. Required for canvas validation. May also be supplied via the `x-application-extension-id` header or `applicationExtensionId` query string on `/config.json` for local tooling. |
+| `APPLICATION_EXTENSION_ID` | Journey Builder **Application Extension ID** generated when installing the Custom Activity package. Required for canvas validation. May also be supplied via the `x-application-extension-id`, `x-application-key`, or `x-app-key` header (Salesforce varies by stack) or the `applicationExtensionId` query string on `/config.json` for local tooling. |
 | `PORT` | Express listen port (defaults to `3001`). |
 | `LOG_LEVEL` | Minimum log level (`debug`, `info`, `warn`, `error`). Defaults to `info`. |
 | `DIGO_API_URL` | Provider API endpoint. Must be configured for outbound requests. |

--- a/config-json.js
+++ b/config-json.js
@@ -44,9 +44,17 @@ function resolveApplicationExtensionId(req) {
   }
 
   if (req && typeof req.get === 'function') {
-    const headerValue = req.get('x-application-extension-id');
-    if (headerValue && headerValue.trim()) {
-      return headerValue.trim();
+    const headerCandidates = [
+      'x-application-extension-id',
+      'x-application-key',
+      'x-app-key'
+    ];
+
+    for (const headerName of headerCandidates) {
+      const headerValue = req.get(headerName);
+      if (headerValue && headerValue.trim()) {
+        return headerValue.trim();
+      }
     }
   }
 

--- a/docs/files/config-json.js.md
+++ b/docs/files/config-json.js.md
@@ -18,7 +18,7 @@ Generates the `config.json` payload consumed by SFMC Journey Builder when loadin
 
 ## External Dependencies
 
-* Relies on process environment variables: `PUBLIC_BASE_URL` to override base URL detection and `APPLICATION_EXTENSION_ID` to satisfy Journey Builder validation. The extension identifier can also be supplied via the `x-application-extension-id` header or `applicationExtensionId` query string when the environment variable is not set (useful for local testing tools).
+* Relies on process environment variables: `PUBLIC_BASE_URL` to override base URL detection and `APPLICATION_EXTENSION_ID` to satisfy Journey Builder validation. The extension identifier can also be supplied via the `x-application-extension-id`, `x-application-key`, or `x-app-key` headers (Salesforce has used multiple variants historically) or via the `applicationExtensionId` query string when the environment variable is not set—useful for local testing tools.
 * References static assets stored under `/images`.
 
 ## Data Flow


### PR DESCRIPTION
## Summary
- allow config.json to honor multiple Journey Builder header names when resolving the application extension id
- document the accepted header variants in both the README and file-level docs for config-json.js

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbdc31f8a08330b714bee437b01871