### PR TITLE
Use boolean isNullable flags in execute schema

### DIFF
--- a/config-json.js
+++ b/config-json.js
@@ -88,19 +88,19 @@ module.exports = function configJSON(req) {
             {
               message: {
                 dataType: 'Text',
-                isNullable: 'False',
+                isNullable: false,
                 direction: 'in',
                 access: 'visible'
               },
               firstNameAttribute: {
                 dataType: 'Text',
-                isNullable: 'True',
+                isNullable: true,
                 direction: 'in',
                 access: 'visible'
               },
               mobilePhoneAttribute: {
                 dataType: 'Text',
-                isNullable: 'False',
+                isNullable: false,
                 direction: 'in',
                 access: 'visible'
               }


### PR DESCRIPTION
## Summary
- replace the execute argument schema's `isNullable` values with boolean literals so Journey Builder reads them correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcc51ced688330a58e9b126a4c7809