### PR TITLE
Ensure root level inArguments for lifecycle compatibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -173,6 +173,16 @@ function onDoneButtonClick() {
   activity.metaData.isConfigured = true
   activity.arguments.execute.inArguments = [inArgument]
 
+  // Some Journey Builder lifecycle requests (notably save/validate) expect
+  // inArguments at the root of the activity payload as well.  Providing the
+  // merged value here makes the configuration resilient if the platform falls
+  // back to activity.inArguments rather than the execute scope.  This also
+  // ensures our server side validators receive the configuration that the
+  // builder persisted, preventing "save lifecycle received without
+  // inArguments" warnings.
+  activity.inArguments = [inArgument]
+  activity.outArguments = activity.outArguments || []
+
   connection.trigger('updateActivity', activity)
   console.log(`Activity has been updated. Activity: ${JSON.stringify(activity)}`)
 }


### PR DESCRIPTION
## Summary
- mirror the execute inArguments onto the activity root payload when saving
- document why the extra assignment is necessary for Journey Builder lifecycle hooks

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dcf5d37a60833087333411f04230e6